### PR TITLE
Stereo / Multichannel Processing

### DIFF
--- a/src/compiler/codegen/codegen_visitor.cpp
+++ b/src/compiler/codegen/codegen_visitor.cpp
@@ -197,8 +197,9 @@ llvm::Value* CodeGenVisitor::operator()(minst::Function& i) {
     context_hasself = fobjtree->second->hasself;
     hasmemobj = !fobjtree->second->memobjs.empty() || context_hasself;
   }
-
-  auto* ft = (i.name != "dsp") ? createFunctionType(i) : createDspFnType(i, hascapture, hasmemobj);
+  bool isdsp = i.name == "dsp";
+  if (isdsp) { G.checkDspFunctionType(i); }
+  auto* ft = !isdsp ? createFunctionType(i) : createDspFnType(i, hascapture, hasmemobj);
   auto* f = createFunction(ft, i);
   recursivefn_ptr = &i;
   G.curfunc = f;
@@ -224,6 +225,7 @@ llvm::FunctionType* CodeGenVisitor::createDspFnType(minst::Function& i, bool has
     argtypes.emplace_back(dummytype);
     argtypes.emplace_back(dummytype);
   }
+  if (i.args.args.empty()) { argtypes.emplace_back(dummytype); }
   if (!hasmemobj && hascapture) { argtypes.emplace_back(dummytype); }
   if (hasmemobj && !hascapture) { argtypes.insert(std::prev(argtypes.end()), dummytype); }
 
@@ -248,6 +250,7 @@ llvm::Function* CodeGenVisitor::createFunction(llvm::FunctionType* type, minst::
 }
 void CodeGenVisitor::addArgstoMap(llvm::Function* f, minst::Function& i, bool hascapture,
                                   bool hasmemobj) {
+  const bool isdsp = i.name == "dsp";
   // arguments are [actual arguments], capture , memobjs
   auto* arg = std::begin(f->args());
   if (auto a = i.args.ret_ptr) {
@@ -265,7 +268,7 @@ void CodeGenVisitor::addArgstoMap(llvm::Function* f, minst::Function& i, bool ha
     arg->setName(name);
     setFvsToMap(i, arg);
     std::advance(arg, 1);
-  } else if (i.name == "dsp") {
+  } else if (isdsp) {
     std::advance(arg, 1);
   }
   if (hasmemobj) {

--- a/src/compiler/codegen/llvmgenerator.hpp
+++ b/src/compiler/codegen/llvmgenerator.hpp
@@ -50,8 +50,8 @@ class LLVMGenerator {
   struct {
     llvm::Value* capptr = nullptr;
     llvm::Value* memobjptr = nullptr;
-    int in_numchs;
-    int out_numchs;
+    int in_numchs =0;
+    int out_numchs =0;
   } runtime_dspfninfo;
 
   void switchToMainFun();

--- a/src/compiler/codegen/llvmgenerator.hpp
+++ b/src/compiler/codegen/llvmgenerator.hpp
@@ -48,6 +48,7 @@ class LLVMGenerator {
   const std::unordered_map<std::string, llvm::Type*> runtime_fun_names;
 
   struct {
+    public:
     llvm::Value* capptr = nullptr;
     llvm::Value* memobjptr = nullptr;
     int in_numchs =0;

--- a/src/compiler/codegen/llvmgenerator.hpp
+++ b/src/compiler/codegen/llvmgenerator.hpp
@@ -67,6 +67,9 @@ class LLVMGenerator {
 
   void setBB(llvm::BasicBlock* newblock);
   void dropAllReferences();
+
+  llvm::Value* getRuntimeInstance();
+
   auto getDoubleTy() { return llvm::Type::getDoubleTy(ctx); }
   auto geti8PtrTy() { return builder->getInt8PtrTy(); }
   auto geti64Ty() { return builder->getInt64Ty(); }

--- a/src/compiler/codegen/llvmgenerator.hpp
+++ b/src/compiler/codegen/llvmgenerator.hpp
@@ -50,6 +50,8 @@ class LLVMGenerator {
   struct {
     llvm::Value* capptr = nullptr;
     llvm::Value* memobjptr = nullptr;
+    int in_numchs;
+    int out_numchs;
   } runtime_dspfninfo;
 
   void switchToMainFun();
@@ -60,11 +62,12 @@ class LLVMGenerator {
 
   void createMiscDeclarations();
   void createRuntimeSetDspFn(llvm::Type* memobjtype);
+  void checkDspFunctionType(minst::Function const& i);
+  static std::optional<int> getDspFnChannelNumForType(types::Value const& t);
   void createMainFun();
   void createTaskRegister(bool isclosure);
   void createNewBasicBlock(std::string name, llvm::Function* f);
   void visitInstructions(mir::valueptr inst, bool isglobal);
-
   void setBB(llvm::BasicBlock* newblock);
   void dropAllReferences();
 
@@ -80,6 +83,7 @@ class LLVMGenerator {
   auto getConstDouble(double v) { return llvm::ConstantFP::get(builder->getDoubleTy(), v); }
 
   auto getZero(const int bitsize = 64) { return getConstInt(0, bitsize); }
+
 };
 
 }  // namespace mimium

--- a/src/llloader.cpp
+++ b/src/llloader.cpp
@@ -64,7 +64,7 @@ auto main(int argc, char** argv) -> int {
   std::unique_ptr<mimium::Runtime_LLVM> runtime;
 
   shutdown_handler = [&runtime](int /*signal*/) {
-    runtime->getAudioDriver()->stop();
+    runtime->getAudioDriver().stop();
 
     std::cerr << "Interuppted by key" << std::endl;
     exit(0);
@@ -82,7 +82,7 @@ auto main(int argc, char** argv) -> int {
       auto m = llvm::parseIRFile(abspath, errorreporter, *llvmcontext);
 
       runtime = std::make_unique<mimium::Runtime_LLVM>(
-          std::move(llvmcontext), tmpfilename, std::make_shared<mimium::AudioDriverRtAudio>());
+          std::move(llvmcontext), tmpfilename, std::make_unique<mimium::AudioDriverRtAudio>());
       m->setDataLayout(runtime->getJitEngine().getDataLayout());
       runtime->executeModule(std::move(m));
       runtime->start();  // start() blocks thread until scheduler stops
@@ -92,7 +92,7 @@ auto main(int argc, char** argv) -> int {
       mimium::Logger::debug_log(e.what(), mimium::Logger::ERROR_);
       returncode = 1;
     }
-    if (runtime) { runtime->getAudioDriver()->stop(); }
+    if (runtime) { runtime->getAudioDriver().stop(); }
   }
   llvm::errs() << "return code: " << returncode << "\n";
   return returncode;

--- a/src/llloader.cpp
+++ b/src/llloader.cpp
@@ -26,9 +26,6 @@ using Logger = mimium::Logger;
 #include "runtime/JIT/runtime_jit.hpp"
 #include "runtime/backend/rtaudio/driver_rtaudio.hpp"
 
-extern "C" {
-extern mimium::Runtime* global_runtime;
-}
 std::function<void(int)> shutdown_handler;
 void signalHandler(int signo) { shutdown_handler(signo); }
 
@@ -86,7 +83,6 @@ auto main(int argc, char** argv) -> int {
 
       runtime = std::make_unique<mimium::Runtime_LLVM>(
           std::move(llvmcontext), tmpfilename, std::make_shared<mimium::AudioDriverRtAudio>());
-      global_runtime = runtime.get();
       m->setDataLayout(runtime->getJitEngine().getDataLayout());
       runtime->executeModule(std::move(m));
       runtime->start();  // start() blocks thread until scheduler stops

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ auto main(int argc, char** argv) -> int {
   auto compiler = std::make_unique<mimium::Compiler>();
   std::unique_ptr<mimium::Runtime_LLVM> runtime;
   shutdown_handler = [&runtime](int /*signal*/) {
-    runtime->getAudioDriver()->stop();
+    runtime->getAudioDriver().stop();
     std::cerr << "Interuppted by key" << std::endl;
     exit(0);
   };
@@ -127,7 +127,7 @@ auto main(int argc, char** argv) -> int {
           break;
         }
         runtime = std::make_unique<mimium::Runtime_LLVM>(
-            compiler->moveLLVMCtx(), tmpfilename, std::make_shared<mimium::AudioDriverRtAudio>());
+            compiler->moveLLVMCtx(), tmpfilename, std::make_unique<mimium::AudioDriverRtAudio>());
         auto llvmmodule = compiler->moveLLVMModule();
         llvmmodule->setDataLayout(runtime->getJitEngine().getDataLayout());
         runtime->executeModule(std::move(llvmmodule));
@@ -141,7 +141,7 @@ auto main(int argc, char** argv) -> int {
 
       returncode = 1;
     }
-    if (runtime) { runtime->getAudioDriver()->stop(); }
+    if (runtime) { runtime->getAudioDriver().stop(); }
   }
   std::cerr << "return code: " << returncode << std::endl;
   return returncode;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,9 +24,7 @@ using Logger = mimium::Logger;
 #include "runtime/JIT/runtime_jit.hpp"
 #include "runtime/backend/rtaudio/driver_rtaudio.hpp"
 
-extern "C" {
-extern mimium::Runtime* global_runtime;
-}
+
 std::function<void(int)> shutdown_handler;
 void signalHandler(int signo) { shutdown_handler(signo); }
 
@@ -131,7 +129,6 @@ auto main(int argc, char** argv) -> int {
         runtime = std::make_unique<mimium::Runtime_LLVM>(
             compiler->moveLLVMCtx(), tmpfilename, std::make_shared<mimium::AudioDriverRtAudio>());
         auto llvmmodule = compiler->moveLLVMModule();
-        global_runtime = runtime.get();
         llvmmodule->setDataLayout(runtime->getJitEngine().getDataLayout());
         runtime->executeModule(std::move(llvmmodule));
         runtime->start();  // start() blocks thread until scheduler stops

--- a/src/runtime/JIT/runtime_jit.cpp
+++ b/src/runtime/JIT/runtime_jit.cpp
@@ -64,7 +64,7 @@ void Runtime_LLVM::executeModule(std::unique_ptr<llvm::Module> module) {
 
   if (auto symbolorerror = jitengine->lookup("dsp")) {
     auto address = (DspFnPtr)symbolorerror->getAddress();
-    hasdsp = true;Ï
+    hasdsp = true;
   } else {
     auto err = symbolorerror.takeError();
     hasdsp = false;

--- a/src/runtime/JIT/runtime_jit.hpp
+++ b/src/runtime/JIT/runtime_jit.hpp
@@ -12,7 +12,7 @@ class Runtime_LLVM : public Runtime, public std::enable_shared_from_this<Runtime
  public:
   explicit Runtime_LLVM(std::unique_ptr<llvm::LLVMContext> ctx,
                         std::string const& filename = "untitled.mmm",
-                        std::shared_ptr<AudioDriver> a = nullptr, bool isjit = true);
+                        std::unique_ptr<AudioDriver> a = nullptr, bool isjit = true);
 
   ~Runtime_LLVM() = default;
   void start() override;
@@ -26,11 +26,12 @@ class Runtime_LLVM : public Runtime, public std::enable_shared_from_this<Runtime
 };
 
 extern "C" {
-void setDspParams(void* runtimeptr,void* dspfn, void* clsaddress, void* memobjaddress);
-void addTask(void* runtimeptr,double time, void* addresstofn, double arg);
-void addTask_cls(void* runtimeptr,double time, void* addresstofn, double arg, void* addresstocls);
+void setDspParams(void* runtimeptr, void* dspfn, void* clsaddress, void* memobjaddress,
+                  int in_numchs, int out_numchs);
+void addTask(void* runtimeptr, double time, void* addresstofn, double arg);
+void addTask_cls(void* runtimeptr, double time, void* addresstofn, double arg, void* addresstocls);
 double mimium_getnow(void* runtimeptr);
-void* mimium_malloc(void* runtimeptr,size_t size);
+void* mimium_malloc(void* runtimeptr, size_t size);
 }
 
 }  // namespace mimium

--- a/src/runtime/JIT/runtime_jit.hpp
+++ b/src/runtime/JIT/runtime_jit.hpp
@@ -26,11 +26,11 @@ class Runtime_LLVM : public Runtime, public std::enable_shared_from_this<Runtime
 };
 
 extern "C" {
-void setDspParams(void* dspfn, void* clsaddress, void* memobjaddress);
-void addTask(double time, void* addresstofn, double arg);
-void addTask_cls(double time, void* addresstofn, double arg, void* addresstocls);
-double mimium_getnow();
-void* mimium_malloc(size_t size);
+void setDspParams(void* runtimeptr,void* dspfn, void* clsaddress, void* memobjaddress);
+void addTask(void* runtimeptr,double time, void* addresstofn, double arg);
+void addTask_cls(void* runtimeptr,double time, void* addresstofn, double arg, void* addresstocls);
+double mimium_getnow(void* runtimeptr);
+void* mimium_malloc(void* runtimeptr,size_t size);
 }
 
 }  // namespace mimium

--- a/src/runtime/backend/audiodriver.cpp
+++ b/src/runtime/backend/audiodriver.cpp
@@ -1,17 +1,7 @@
 #include "audiodriver.hpp"
 namespace mimium {
 
-bool AudioDriver::processSample(double* input, double* output) {
-  auto shouldstop = sch.incrementTime();
-  if (shouldstop) {
-    sch.stop();
-    return false;
-  }
-  if (dspfninfos.fn != nullptr) {
-    double res = dspfninfos.fn(static_cast<double>(sch.getTime()), dspfninfos.cls_address, dspfninfos.memobj_address);
-    for (int ch = 0; ch < this->channels; ch++) { output[ch] = res; }
-  }
-  return true;
-}
+
+
 
 }  // namespace mimium

--- a/src/runtime/backend/audiodriver.hpp
+++ b/src/runtime/backend/audiodriver.hpp
@@ -8,28 +8,155 @@
 
 namespace mimium {
 
-
 class AudioDriver {
  protected:
-  unsigned int buffer_size;  // 256 sample per frames
-  unsigned int sample_rate;
-  unsigned int channels;
+  std::unique_ptr<AudioDriverParams> params;
+  std::unique_ptr<DspFnInfos> dspfninfos;
   Scheduler sch;
-  DspFnInfos dspfninfos;
 
  public:
-  AudioDriver() = delete;
-  explicit AudioDriver(unsigned int bs = 256,
-                       unsigned int sr = 44100, unsigned int chs = 2)
-      : buffer_size(bs), sample_rate(sr), channels(chs), sch(){};
-  void setDspFnInfos(DspFnInfos&& infos) { 
-    dspfninfos = infos;
-  }
+  AudioDriver()
+      : params(nullptr),
+        sch(){
+
+        };
   virtual ~AudioDriver() = default;
   Scheduler& getScheduler() { return sch; }
-  virtual bool start() = 0;
+  void setDspFnInfos(std::unique_ptr<DspFnInfos> p) {
+    dspfninfos = std::move(p);
+    Logger::debug_log("dsp function:" + std::to_string(dspfninfos->in_numchs) + " input, " +
+                          std::to_string(dspfninfos->out_numchs) + " output",
+                      Logger::INFO);
+  }
+  virtual void setup(std::unique_ptr<AudioDriverParams> p) {
+    params = std::move(p);
+    interleaved_in.resize(params->buffersize * dspfninfos->in_numchs);
+    interleaved_out.resize(params->buffersize * dspfninfos->out_numchs);
+    if (dspfninfos->in_numchs > params->in_numchs || dspfninfos->out_numchs > params->out_numchs) {
+      Logger::debug_log(
+          "Number of inputs/outputs is bigger than number of the audio driver's inputs/outputs.",
+          Logger::WARNING);
+    }
+  }
+  virtual bool start() {
+    assert(params != nullptr);
+    assert(dspfninfos != nullptr);
+    return true;
+  };
   virtual bool stop() = 0;
-  bool processSample(double* input, double* output);
-};
+  // Main dsp process function
+  bool process(const double** input, double** output) {
+    bool res = true;
+    if (dspfninfos->fn != nullptr) {
+      res &= processInternal<true>(input, output, params->buffersize);
+    } else {
+      res &= processInternal<false>(input, output, params->buffersize);
+    }
+    return res;
+  }
+  // Interleaved version of main dsp process.
+  bool process(const double* input, double* output) {
+    bool res = true;
+    if (dspfninfos->fn != nullptr) {
+      res &= processInternalInterleaved<true>(input, output);
+    } else {
+      res &= processInternalInterleaved<false>(input, output);
+    }
+    return res;
+  }
 
+ private:
+  std::vector<double> interleaved_in;
+  std::vector<double> interleaved_out;
+
+  // buffer copy into vector from pointer of poitner
+  static void interleaveSamples(const double** src, std::vector<double>& dest, int bufsize,
+                                int dsp_chans, int device_chans) {
+    for (int ch = 0; ch < dsp_chans; ch++) {
+      const auto* samples_ch = *std::next(src, ch);
+      if (ch < device_chans) {
+        for (int count = 0; count < bufsize; count++) {
+          dest.at(count + count * ch) = *std::next(samples_ch, count);
+        }
+      } else {
+        for (int count = 0; count < bufsize; count++) { dest.at(count + count * ch) = 0; }
+      }
+    }
+  }
+  // buffer copy into pointer of poitner from vector
+  static void deinterleaveSamples(std::vector<double> const& src, double** dest, int bufsize,
+                                  int dsp_chans, int device_chans) {
+    for (int ch = 0; ch < dsp_chans; ch++) {
+      auto* dest_ch = *std::next(dest, ch);
+      if (ch < device_chans) {
+        for (int count = 0; count < bufsize; count++) {
+          *std::next(dest_ch, count) = src.at(count + count * ch);
+        }
+      } else {
+        std::fill(dest_ch, std::next(dest_ch, bufsize), 0);
+      }
+    }
+  }
+
+  template <bool HASDSP>
+  bool processInternal(const double** input, double** output, int bufsize) {
+    bool res = true;
+    interleaveSamples(input, interleaved_in, bufsize, dspfninfos->in_numchs, params->in_numchs);
+    for (int count = 0; count < bufsize; count++) {
+      res &= this->processSample<HASDSP>(interleaved_in.data(), interleaved_out.data());
+    }
+    deinterleaveSamples(interleaved_out, output, bufsize, dspfninfos->out_numchs,
+                        params->out_numchs);
+    return res;
+  }
+
+  template <bool HASDSP>
+  bool processSample(const double* input, double* output) {
+    auto shouldstop = sch.incrementTime();
+    if (shouldstop) {
+      sch.stop();
+      return false;
+    }
+    if constexpr (HASDSP) {
+      dspfninfos->fn(output, input, dspfninfos->cls_address, dspfninfos->memobj_address);
+    }
+    return true;
+  }
+
+  template <bool HASDSP>
+  bool processInternalInterleaved(const double* input, double* output) {
+    if constexpr (HASDSP) {
+      int dsp_ins = dspfninfos->in_numchs;
+      int device_ins = params->in_numchs;
+      int dsp_outs = dspfninfos->out_numchs;
+      int device_outs = params->out_numchs;
+      for (int ch = 0; ch < dsp_ins; ch++) {
+        for (int count = 0; count < params->buffersize; count++) {
+          if (ch > device_ins) {
+            interleaved_in[ch + dsp_ins * count] = input[ch + device_ins * count];
+          } else {
+            interleaved_in[ch + dsp_ins * count] = 0;
+          }
+        }
+      }
+      bool res = true;
+      for (int count = 0; count < params->buffersize; count++) {
+        res &= processSample<true>(std::next(interleaved_in.data(), count * dsp_ins),
+                                   std::next(interleaved_out.data(), count * dsp_outs));
+      }
+      for (int ch = 0; ch < dsp_outs; ch++) {
+        for (int count = 0; count < params->buffersize; count++) {
+          if (ch < device_outs) {
+            output[ch + device_outs * count] = interleaved_out[ch + dsp_outs * count];
+          } else {
+            output[ch + device_outs * count] = 0;
+          }
+        }
+      }
+      return res;
+    } else {
+      return processSample<false>(input, output);
+    }
+  }
+};
 };  // namespace mimium

--- a/src/runtime/backend/rtaudio/driver_rtaudio.cpp
+++ b/src/runtime/backend/rtaudio/driver_rtaudio.cpp
@@ -5,46 +5,72 @@
 #include "runtime/backend/rtaudio/driver_rtaudio.hpp"
 
 namespace mimium {
-AudioDriverRtAudio::AudioDriverRtAudio(unsigned int bs, unsigned int sr, unsigned int chs)
-    : AudioDriver(bs, sr, chs) {
+AudioDriverRtAudio::AudioDriverRtAudio(int buffer_size)
+    : AudioDriver(), bufsize_internal(buffer_size) {
   try {
     rtaudio = std::make_unique<RtAudio>();
   } catch (RtAudioError& e) { e.printMessage(); }
 
   if (rtaudio->getDeviceCount() < 1) { throw std::runtime_error("No audio devices found!"); }
-  parameters.deviceId = rtaudio->getDefaultOutputDevice();
-  parameters.nChannels = chs;
-  parameters.firstChannel = 0;
+  rtaudio_params_input.deviceId = rtaudio->getDefaultInputDevice();
+  rtaudio_params_output.deviceId = rtaudio->getDefaultOutputDevice();
+  rtaudio_params_input.nChannels = getInputDevice().inputChannels;
+  rtaudio_params_output.nChannels = getOutputDevice().outputChannels;
+  rtaudio_params_input.firstChannel = 0;
+  rtaudio_params_output.firstChannel = 0;
 }
 RtAudioCallback AudioDriverRtAudio::callback = [](void* output, void* input, unsigned int nFrames,
                                                   double time, RtAudioStreamStatus status,
                                                   void* userdata) -> int {
   auto* driver = static_cast<AudioDriverRtAudio*>(userdata);
-
-  auto* input_d = static_cast<double*>(input);
-  auto* output_d = static_cast<double*>(output);
+  // Process interleaved audio data.
+  driver->process(static_cast<const double*>(input), static_cast<double*>(output));
   if (status > 0) { Logger::debug_log("Stream underflow detected!", Logger::WARNING); }
-  // Write interleaved audio data.
-  for (int i = 0; i < nFrames; i++) {
-    double* output_pos = std::next(output_d, i * driver->channels);
-    double* input_pos = std::next(input_d, i * driver->channels);
-    driver->processSample(input_pos, output_pos);
-  }
   return status;
 };
 
+[[nodiscard]] unsigned int AudioDriverRtAudio::getPreferredSampleRate() const {
+  auto sr_in = getInputDevice().preferredSampleRate;
+  auto sr_out = getOutputDevice().preferredSampleRate;
+  if (sr_in != sr_out) {
+    Logger::debug_log("input & output sample rates are different. Uses output's samplerate :" +
+                          std::to_string(sr_out),
+                      Logger::WARNING);
+  }
+  return sr_out;
+}
+void AudioDriverRtAudio::printStreamInfo() const {
+  std::string deviceinfostr;
+  auto indevice = getInputDevice();
+  auto outdevice = getOutputDevice();
+  deviceinfostr += "Input Audio Device : " + indevice.name;
+  deviceinfostr += " - " + std::to_string(indevice.inputChannels) + "chs\n ";
+  deviceinfostr += "Output Audio Device : " + outdevice.name;
+  deviceinfostr += " - " + std::to_string(outdevice.outputChannels) + "chs\n ";
+  deviceinfostr += "Sampling Rate : " + std::to_string(rtaudio->getStreamSampleRate());
+  deviceinfostr += " / Buffer Size : " + std::to_string(bufsize_internal);
+  Logger::debug_log(deviceinfostr, Logger::INFO);
+}
 bool AudioDriverRtAudio::start() {
   try {
-    sample_rate = rtaudio->getDeviceInfo(parameters.deviceId).preferredSampleRate;
-    rtaudio->openStream(&parameters, nullptr, RTAUDIO_FLOAT64, sample_rate, &buffer_size,
-                        AudioDriverRtAudio::callback, this);
-    std::string deviceinfo = "Audio Device : ";
-    auto device = rtaudio->getDeviceInfo(rtaudio->getDefaultOutputDevice());
-    deviceinfo += device.name;
-    deviceinfo += ", Sampling Rate : " + std::to_string(rtaudio->getStreamSampleRate());
-    deviceinfo += ", Output Channels : " + std::to_string(device.outputChannels);
-    Logger::debug_log(deviceinfo, Logger::INFO);
-    bool hasdsp = dspfninfos.fn != nullptr;
+    rtaudio_options.streamName = "mimium";
+    auto sr = getPreferredSampleRate();
+
+    auto p = std::make_unique<AudioDriverParams>(
+        AudioDriverParams{static_cast<double>(sr), static_cast<int>(bufsize_internal),
+                          static_cast<int>(rtaudio_params_input.nChannels),
+                          static_cast<int>(rtaudio_params_output.nChannels)});
+    // check parameter are valid
+    AudioDriver::setup(std::move(p));
+    AudioDriver::start();
+    rtaudio->openStream(&rtaudio_params_output, &rtaudio_params_input, RTAUDIO_FLOAT64, sr,
+                        &bufsize_internal, AudioDriverRtAudio::callback, this, &rtaudio_options,
+                        nullptr);
+    params->buffersize = static_cast<int>(bufsize_internal);
+
+    printStreamInfo();
+
+    bool hasdsp = dspfninfos->fn != nullptr;
     sch.start(hasdsp);
     rtaudio->startStream();
   } catch (RtAudioError& e) {

--- a/src/runtime/backend/rtaudio/driver_rtaudio.hpp
+++ b/src/runtime/backend/rtaudio/driver_rtaudio.hpp
@@ -11,12 +11,20 @@ class Scheduler;
 
 class AudioDriverRtAudio : public AudioDriver {
   std::unique_ptr<RtAudio> rtaudio;
-  RtAudio::StreamParameters parameters;
+  RtAudio::StreamParameters rtaudio_params_input;
+  RtAudio::StreamParameters rtaudio_params_output;
+  RtAudio::StreamOptions rtaudio_options;
   bool setCallback();
+  unsigned int bufsize_internal;
+  std::vector<std::unique_ptr<std::vector<double>>> in_buffer;
+  std::vector<std::unique_ptr<std::vector<double>>> out_buffer;
 
+  [[nodiscard]] unsigned int getPreferredSampleRate() const;
+  auto getInputDevice() const { return rtaudio->getDeviceInfo(rtaudio_params_input.deviceId); }
+  auto getOutputDevice() const { return rtaudio->getDeviceInfo(rtaudio_params_output.deviceId); }
+  void printStreamInfo()const;
  public:
-  explicit AudioDriverRtAudio(unsigned int bs = 256,
-                       unsigned int sr = 44100, unsigned int chs = 2);
+  explicit AudioDriverRtAudio(int buffer_size = 256);
   ~AudioDriverRtAudio() override = default;
   bool start() override;
   bool stop() override;

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -14,20 +14,20 @@ class AudioDriver;
 
 class Runtime {
  public:
-  explicit Runtime(std::string const& filename_i = "untitled",std::shared_ptr<AudioDriver> a=nullptr):audiodriver(std::move(a))  {}
+  explicit Runtime(std::string const& filename_i = "untitled",std::unique_ptr<AudioDriver> a=nullptr):audiodriver(std::move(a))  {}
 
   ~Runtime() {
     for (auto&& [address, size] : malloc_container) { free(address); }
   };
 
   virtual void start() = 0;
-  auto getAudioDriver() { return audiodriver; }
+  auto& getAudioDriver() { return *audiodriver; }
   bool hasDsp() { return hasdsp; }
   bool hasDspCls() { return hasdspcls; }
   void push_malloc(void* address, size_t size) { malloc_container.emplace_back(address, size); }
 
  protected:
-  std::shared_ptr<AudioDriver> audiodriver;
+  std::unique_ptr<AudioDriver> audiodriver;
   bool hasdsp = false;
   bool hasdspcls = false;
   std::list<std::pair<void*, size_t>> malloc_container{};

--- a/src/runtime/runtime_defs.hpp
+++ b/src/runtime/runtime_defs.hpp
@@ -11,21 +11,21 @@ using DspFnPtr = void (*)(double*, const double*, void*, void*);
 // Information set by definition of dsp function.
 // number of in&out channels are determined by type of dsp function.
 struct DspFnInfos {
-  DspFnPtr fn;
-  void* cls_address;
-  void* memobj_address;
-  int in_numchs;
-  int out_numchs;
+  DspFnPtr fn = nullptr;
+  void* cls_address = nullptr;
+  void* memobj_address = nullptr;
+  int in_numchs = 0;
+  int out_numchs = 0;
 };
 
 // Information of AudioDriver(e.g. Hardware Device).
 // number of in&out channels are determined by logical number of device and may be different from
 // DspFnInfos.
 struct AudioDriverParams {
-  double samplerate;
-  int buffersize;
-  int in_numchs;
-  int out_numchs;
+  double samplerate = 0;
+  int buffersize = 0;
+  int in_numchs = 0;
+  int out_numchs = 0;
 };
 
 }  // namespace mimium

--- a/src/runtime/runtime_defs.hpp
+++ b/src/runtime/runtime_defs.hpp
@@ -4,12 +4,28 @@
 
 #pragma once
 namespace mimium {
-using DspFnPtr = double (*)(double, void*, void*);
 
-struct DspFnInfos{
-    DspFnPtr fn;
-    void* cls_address;
-    void* memobj_address;
+// outputresult,input, clsaddress,memobjaddress
+using DspFnPtr = void (*)(double*, const double*, void*, void*);
+
+// Information set by definition of dsp function.
+// number of in&out channels are determined by type of dsp function.
+struct DspFnInfos {
+  DspFnPtr fn;
+  void* cls_address;
+  void* memobj_address;
+  int in_numchs;
+  int out_numchs;
 };
 
-}
+// Information of AudioDriver(e.g. Hardware Device).
+// number of in&out channels are determined by logical number of device and may be different from
+// DspFnInfos.
+struct AudioDriverParams {
+  double samplerate;
+  int buffersize;
+  int in_numchs;
+  int out_numchs;
+};
+
+}  // namespace mimium

--- a/src/runtime/runtime_defs.hpp
+++ b/src/runtime/runtime_defs.hpp
@@ -11,6 +11,7 @@ using DspFnPtr = void (*)(double*, const double*, void*, void*);
 // Information set by definition of dsp function.
 // number of in&out channels are determined by type of dsp function.
 struct DspFnInfos {
+  public:
   DspFnPtr fn = nullptr;
   void* cls_address = nullptr;
   void* memobj_address = nullptr;
@@ -22,6 +23,7 @@ struct DspFnInfos {
 // number of in&out channels are determined by logical number of device and may be different from
 // DspFnInfos.
 struct AudioDriverParams {
+  public:
   double samplerate = 0;
   int buffersize = 0;
   int in_numchs = 0;


### PR DESCRIPTION
This pr is the first implementation of multichannel audio processing with an improved architecture of an audio driver.

## Breaking Changes

- Arguments for `dsp` function is no longer `time` (old implementation before `now` implemented) but Tuple of float types(`(float,float,...)`).
- Return type also should be Tuple of float even in the case of mono processing.
   - In the future, this strategy may be fixed so that we can use just float type instead of Tuple of single float.

---

The compiler checks a type of `dsp` function on a compilation. 

AudioDriver should handle differences in the number of in/out channels between `dsp` function and the hardware device.

## Other major changes

Runtime-related functions such as `mimium_getnow()` were using global variable to simplify implementation.
These implementations are now changed to taking a pointer to an instance of the runtime as an argument.
The pointer to runtime is passed from an argument of `mimium_main` function and stored in a global variable(private linkage) in llvm module.
