### PR TITLE
Added code coverage analysis setting

### DIFF
--- a/mimium.code-workspace
+++ b/mimium.code-workspace
@@ -9,7 +9,8 @@
 			"ms-vscode.cmake-tools",
 			"rreverser.llvm",
 			"llvm-vs-code-extensions.vscode-clangd",
-			"vadimcn.vscode-lldb"
+			"vadimcn.vscode-lldb",
+			"ryanluker.vscode-coverage-gutters"
         ]
     },
 	"settings": {
@@ -29,7 +30,7 @@
 					"type": "lldb",
 					"request": "launch",
 					"program": "${command:cmake.launchTargetPath}",
-					"args": [ "${workspaceFolder}/test/mmm/test_tupletofn.mmm"], 
+					"args": [ "${workspaceFolder}/test/mmm/test_stereopan.mmm"], 
 					"cwd": "${workspaceFolder}/build", 
 				},
 			]
@@ -51,7 +52,12 @@
 		  ],
 		"cmake.configureArgs": [
 			"-DBUILD_TEST=ON",
+			"-DENABLE_COVERAGE=ON",
 			// "-DENABLE_LLD=ON"
-		]
-	}
+		],
+		"coverage-gutters.coverageBaseDir": "build",
+		"coverage-gutters.showRulerCoverage": true,
+		"coverage-gutters.customizable.status-bar-toggler-watchCoverageAndVisibleEditors-enabled": false,
+		
+	},
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
+
+
+
 add_subdirectory(googletest)
 
 file(GLOB SRCS ./*.cpp)
@@ -14,7 +17,18 @@ target_include_directories(UnitTest
     ${FLEX_INCLUDE_CACHE}
     ${PARSER_HEADER_DIR}
     )
-
+if(ENABLE_COVERAGE)
+  add_custom_target(Lcov
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND lcov -c -d . -o lcov.info
+  COMMAND lcov -r lcov.info "*/googletest/*" "*/c++/*" "/usr/local/*" -o lcov.info
+  BYPRODUCTS ${CMAKE_BINARY_DIR}/lcov.info
+  )
+  add_custom_target(LcovResetCounter
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  COMMAND lcov --zerocounters -d .
+  )
+endif()
 target_link_libraries(UnitTest
   PRIVATE
     gtest_main


### PR DESCRIPTION
Added setting for cmake and vscode-workspace for code coverage analysis using gcov & lcov.

- When `-DENABLE_COVERAGE=ON` is added to make config option, `--coverage` flag is passed to compiler & linker flag.
- `ENABLE_COVERAGE` is OFF in CMake option by default but enabled in the code-workspace setting by default.
- Custom CMake Target `Test/Lcov` and `Test/LcovResetCounter` are added.

To see a result of test coverage,

1.  install Coverage Gutters Extension to vscode (added to workspace recommendation).
2. Build All project with `-DENABLE_COVERAGE=ON`
3. Run UnitTest at least once.
4. Run `Lcov` target in CMake.
5. Run "Coverage Gutters : Display Coverage" from Context menu or Command Palette.