### PR TITLE
Fixed llvm optimization of lljit class

### DIFF
--- a/src/runtime/JIT/runtime_jit.hpp
+++ b/src/runtime/JIT/runtime_jit.hpp
@@ -12,7 +12,7 @@ class Runtime_LLVM : public Runtime, public std::enable_shared_from_this<Runtime
  public:
   explicit Runtime_LLVM(std::unique_ptr<llvm::LLVMContext> ctx,
                         std::string const& filename = "untitled.mmm",
-                        std::unique_ptr<AudioDriver> a = nullptr, bool isjit = true);
+                        std::unique_ptr<AudioDriver> a = nullptr, bool optimize = true);
 
   ~Runtime_LLVM() = default;
   void start() override;


### PR DESCRIPTION
Now an optimization in LLVM properly works on jit execution.
Also, `MimiumJIT` class has an option for the optimization level so that the user can change optimization behavior from CLI(CLI option is not implemented yet).
Currently, the option has just `On` and `Off`  but more levels may be added in the future.