### PR TITLE
small code refactors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,6 @@ endif()
 #include ccache
 include(cmake/EnableCcache.cmake)
 
-add_compile_options("$<$<CONFIG:DEBUG>:-DMIMIUM_DEBUG_BUILD>")
-
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -6,10 +6,19 @@ target_compile_features(mimium_filereader PUBLIC cxx_std_17)
 add_library(mimium_utils STATIC mir.cpp type.cpp ast_to_string.cpp)
 target_include_directories(mimium_utils PUBLIC  ${MIMIUM_SOURCE_DIR})
 target_compile_features(mimium_utils PUBLIC cxx_std_17)
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+
+target_compile_options(mimium_utils PUBLIC
+$<$<CONFIG:Debug>:-O0 -DMIMIUM_DEBUG_BUILD -Wall -pedantic-errors>
+)
+if((CMAKE_BUILD_TYPE STREQUAL "Debug") AND 
+    (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
 message("sanitizer activated")
-target_compile_options(mimium_utils PUBLIC -fsanitize=address -fno-omit-frame-pointer -O0)
-target_link_options(mimium_utils PUBLIC -fsanitize=address)
+target_compile_options(mimium_utils PUBLIC 
+   -fsanitize=address -fno-omit-frame-pointer
+)
+target_link_options(mimium_utils PUBLIC 
+    -fsanitize=address
+)
 endif()
 
 install(TARGETS mimium_utils DESTINATION lib)

--- a/src/basic/ast_to_string.cpp
+++ b/src/basic/ast_to_string.cpp
@@ -6,7 +6,9 @@
 namespace mimium {
 
 ToStringVisitor::ToStringVisitor(std::ostream& output, Mode mode)
-    : output(output), is_prettry(true) {
+    : output(output)
+// ,is_prettry(true)
+{
   this->mode = mode;
   switch (mode) {
     case Mode::Lisp: format = {"(", ")", "(", ")", " ", "\n"}; break;
@@ -143,9 +145,7 @@ void AstStringifier::toString(const ast::Lvar& ast) { std::visit(*this, ast); }
 void AstStringifier::toString(const ast::Expr& ast) { std::visit(*this, ast); }
 void AstStringifier::toString(ast::ExprPtr ast) { std::visit(*this, *ast); }
 
-void AstStringifier::toString(const ast::Statement& ast) {
-  std::visit(*this, ast);
-}
+void AstStringifier::toString(const ast::Statement& ast) { std::visit(*this, ast); }
 void AstStringifier::toString(const ast::Statements& ast) {
   for (auto&& stmt : ast) {
     toString(*stmt);

--- a/src/basic/ast_to_string.hpp
+++ b/src/basic/ast_to_string.hpp
@@ -24,7 +24,7 @@ struct ToStringVisitor {
 
  private:
   Mode mode;
-  bool is_prettry;
+  // bool is_prettry;
 };
 
 struct AstStringifier : public ToStringVisitor {

--- a/src/basic/type.cpp
+++ b/src/basic/type.cpp
@@ -4,6 +4,10 @@
 
 #include "basic/type.hpp"
 
+namespace{
+  mimium::types::ToStringVisitor tostrvisitor;//FIXWARNING
+}
+
 namespace mimium {
 namespace types {
 

--- a/src/compiler/ast_loader.cpp
+++ b/src/compiler/ast_loader.cpp
@@ -5,8 +5,6 @@
 #include "basic/ast_to_string.hpp"
 #include "basic/filereader.hpp"
 
-namespace fs = std::filesystem;
-
 namespace mimium {
 
 AstPtr Driver::parse(std::istream& is) {

--- a/src/compiler/closure_convert.cpp
+++ b/src/compiler/closure_convert.cpp
@@ -49,7 +49,6 @@ mir::blockptr ClosureConverter::convert(mir::blockptr toplevel) {
     ccvis.instance_holder = cinst;
     ccvis.visit(*cinst);
   }
-  // std::visit(typereplacer, cinst);
 
   moveFunToTop(this->toplevel);
   if (!(clstypeenv.count("dsp") > 0)) {
@@ -116,7 +115,6 @@ void ClosureConverter::CCVisitor::operator()(minst::Function& i) {
   auto fn_ptr = getValPtr(&i);
   auto stored_fn_iter = cc.known_functions.insert(cc.known_functions.end(), fn_ptr);
   ccvis.block_ctx = i.body;
-  bool checked = false;
   // first, try assuming the function is not a closure.
   visitinsts(i, ccvis);
   // when the function was really not a closure, end.
@@ -126,12 +124,8 @@ void ClosureConverter::CCVisitor::operator()(minst::Function& i) {
 
   cc.known_functions.erase(stored_fn_iter);
   ccvis.fvset.clear();
-  // cc.known_functions = know_function_tmp;//reset state
-
   visitinsts(i, ccvis);
-  // if (i.isrecursive) {//to replace recursive call to appcls
-  //   visitinsts(i, ccvis,pos);
-  // }
+
   // make closure
   std::vector<types::Value> fvtype_inside;
   fvtype_inside.reserve(ccvis.fvset.size());
@@ -154,9 +148,6 @@ void ClosureConverter::CCVisitor::operator()(minst::Function& i) {
   types::Alias fvtype{cc.makeCaptureName(), types::Tuple{fvtype_inside}};
 
   types::Function ftype = rv::get<types::Function>(i.type);
-  // types::Alias clstype{cc.makeClosureTypeName(),
-  //                      types::Closure{types::Ref{types::Function{ftype}},
-  //                      types::Alias{fvtype}}};
 
   auto makecls = std::make_shared<mir::Value>(createClosureInst(fn_ptr, fvsetvec, fvtype, i.name));
   cc.fn_to_cls.emplace(fn_ptr, makecls);

--- a/src/compiler/codegen/codegen_visitor.cpp
+++ b/src/compiler/codegen/codegen_visitor.cpp
@@ -21,8 +21,8 @@ const std::unordered_map<OpId, std::string> CodeGenVisitor::opid_to_ffi = {
 // Creates Allocation instruction or call malloc function depends on context
 CodeGenVisitor::CodeGenVisitor(LLVMGenerator& g, const funobjmap* funobj_map)
     : G(g),
-      isglobal(false),
       funobj_map(funobj_map),
+      isglobal(false),
       context_hasself(false),
       recursivefn_ptr(nullptr) {}
 
@@ -483,15 +483,11 @@ llvm::Value* CodeGenVisitor::operator()(minst::MakeClosure& i) {
 llvm::Value* CodeGenVisitor::operator()(minst::Array& i) {
   auto* atype = G.getArrayType(i.type);
   auto* gvalue = llvm::cast<llvm::GlobalVariable>(G.module->getOrInsertGlobal(i.name, atype));
-
   std::vector<llvm::Constant*> values = {};
   std::transform(i.args.cbegin(), i.args.cend(), std::back_inserter(values),
                  [&](mir::valueptr v) { return llvm::cast<llvm::Constant>(getLlvmVal(v)); });
   auto* constantarray = llvm::ConstantArray::get(atype, values);
   gvalue->setInitializer(constantarray);
-  auto* first_element = G.builder->CreateInBoundsGEP(gvalue, {G.getZero()}, i.name + "firstelem");
-  auto* ptrval = G.builder->CreateBitCast(
-      first_element, llvm::PointerType::get(atype->getElementType(), 0), i.name + "_ptr");
   return gvalue;
 }
 llvm::Value* CodeGenVisitor::operator()(minst::ArrayAccess& i) {

--- a/src/compiler/collect_memoryobjs.cpp
+++ b/src/compiler/collect_memoryobjs.cpp
@@ -171,7 +171,7 @@ ResultT MemoryObjsCollector::CollectMemVisitor::operator()(minst::Fcall& i) {
                             [&](const mir::ExternalSymbol& e) -> opt_objtreeptr {
                               if (e.name == "delay") {
                                 auto res = std::make_shared<FunObjTree>(
-                                    FunObjTree{i.fname, false, {}, types::delaystruct});
+                                    FunObjTree{i.fname, false, {}, types::getDelayStruct()});
                                 M.result_map.emplace(i.fname, res);
                                 return res;
                               }

--- a/src/compiler/compiler.cpp
+++ b/src/compiler/compiler.cpp
@@ -14,8 +14,8 @@ Compiler::Compiler()
       memobjcollector(),
       llvmgenerator(*llvmctx) {}
 Compiler::Compiler(std::unique_ptr<llvm::LLVMContext> ctx)
-    : driver(),
-      llvmctx(std::move(ctx)),
+    : llvmctx(std::move(ctx)),
+      driver(),
       symbolrenamer(std::make_shared<RenameEnvironment>()),
       typeinferer(),
       mirgenerator(typeinferer.getTypeEnv()),
@@ -29,9 +29,7 @@ void Compiler::setFilePath(std::string path) {
 }
 void Compiler::setDataLayout(const llvm::DataLayout& dl) { llvmgenerator.setDataLayout(dl); }
 
-AstPtr Compiler::loadSource(std::istream& source) {
-  return driver.parse(source);
-}
+AstPtr Compiler::loadSource(std::istream& source) { return driver.parse(source); }
 
 AstPtr Compiler::loadSource(const std::string& source) {
   AstPtr ast = driver.parseString(source);
@@ -53,12 +51,11 @@ llvm::Module& Compiler::generateLLVMIr(mir::blockptr mir, funobjmap const& funob
   llvmgenerator.generateCode(mir, &funobjs);
   return llvmgenerator.getModule();
 }
-  void Compiler::dumpLLVMModule(std::ostream& out){
-    std::string str;
-    llvm::raw_string_ostream tmpout(str);
-    llvmgenerator.getModule().print(tmpout, nullptr);
-    out << str;
-  }
-
+void Compiler::dumpLLVMModule(std::ostream& out) {
+  std::string str;
+  llvm::raw_string_ostream tmpout(str);
+  llvmgenerator.getModule().print(tmpout, nullptr);
+  out << str;
+}
 
 }  // namespace mimium

--- a/src/compiler/compiler.hpp
+++ b/src/compiler/compiler.hpp
@@ -43,14 +43,13 @@ class Compiler {
   auto moveLLVMModule() { return llvmgenerator.moveModule(); }
 
  private:
+  std::unique_ptr<llvm::LLVMContext> llvmctx;
   Driver driver;
-  // AlphaConvertVisitor alphavisitor;
   SymbolRenamer symbolrenamer;
   TypeInferer typeinferer;
   MirGenerator mirgenerator;
   std::shared_ptr<ClosureConverter> closureconverter;
   MemoryObjsCollector memobjcollector;
-  std::unique_ptr<llvm::LLVMContext> llvmctx;
   LLVMGenerator llvmgenerator;
   std::string path;
 };

--- a/src/compiler/ffi.cpp
+++ b/src/compiler/ffi.cpp
@@ -47,7 +47,7 @@ struct MmmRingBuf {
   // int64_t size=5000;
   int64_t readi = 0;
   int64_t writei = 0;
-  double buf[mimium::types::fixed_delaysize];
+  double buf[mimium::types::fixed_delaysize]{};
 };
 double mimium_delayprim(double in, double time, MmmRingBuf* rbuf) {
   auto size = sizeof(rbuf->buf) / sizeof(double);
@@ -82,9 +82,9 @@ double* libsndfile_loadwav(char* filename) {
 }
 
 namespace mimium {
-using namespace types;
+using namespace types;//NOLINT
 using FI = BuiltinFnInfo;
-std::unordered_map<std::string, BuiltinFnInfo> LLVMBuiltin::ftable = {
+const std::unordered_map<std::string, BuiltinFnInfo> LLVMBuiltin::ftable = {
     {"print", initBI(Function{Void{}, {Float{}}}, "printdouble")},
     {"println", initBI(Function{Void{}, {Float{}}}, "printlndouble")},
     {"printlnstr", initBI(Function{Void{}, {String{}}}, "printlnstr")},

--- a/src/compiler/ffi.hpp
+++ b/src/compiler/ffi.hpp
@@ -22,7 +22,7 @@ inline BuiltinFnInfo initBI(types::Function&& f, std::string&& s) {
 }
 
 struct LLVMBuiltin {
-  static std::unordered_map<std::string, BuiltinFnInfo> ftable;
+  const static std::unordered_map<std::string, BuiltinFnInfo> ftable;
   static bool isBuiltin(std::string fname) { return LLVMBuiltin::ftable.count(fname) > 0; }
 };
 

--- a/src/compiler/mirgenerator.cpp
+++ b/src/compiler/mirgenerator.cpp
@@ -9,7 +9,7 @@ namespace mimium {
 // new knormalizer(mir generator)
 
 mir::blockptr MirGenerator::generate(ast::Statements& topast) {
-  auto topblock = ast::Block{ast::DebugInfo{}, topast, std::nullopt};
+  auto topblock = ast::Block{{ast::DebugInfo{}}, topast, std::nullopt};
   auto [optvalptr, ctx] = generateBlock(topblock, "root", std::nullopt);
   return ctx;
 }
@@ -117,7 +117,7 @@ mir::valueptr ExprKnormVisitor::operator()(ast::Symbol& ast) {
   }
   throw std::runtime_error("symbol " + ast.value + " not found");
 }  // namespace mimium
-mir::valueptr ExprKnormVisitor::operator()(ast::Self& ast) {
+mir::valueptr ExprKnormVisitor::operator()(ast::Self&  /*ast*/) {
   // todo: create special type for self
   MMMASSERT(fnctx.has_value(), "Self cannot used in global context");
   auto self = mir::Self{fnctx.value(), types::Float{}};
@@ -257,11 +257,11 @@ mir::valueptr ExprKnormVisitor::operator()(ast::Tuple& ast) {
     tupletypes.emplace_back(mir::getType(*arg));
   }
   types::Value rettype = types::Tuple{{tupletypes}};
-  mir::valueptr lvar = emplace(minst::Allocate{lvname + "_ref", types::Pointer{rettype}});
+  mir::valueptr lvar = emplace(minst::Allocate{{lvname + "_ref", types::Pointer{rettype}}});
   int count = 0;
   for (auto& elem : newelems) {
     auto newlvname = mirgen.makeNewName();
-    auto index = std::make_shared<mir::Value>(mir::Constants{(double)count});
+    auto index = std::make_shared<mir::Value>(mir::Constants{static_cast<double>(count)});
     auto ptrtostore = emplace(minst::Field{{newlvname, tupletypes[count]}, lvar, std::move(index)});
     emplace(minst::Store{{newlvname, tupletypes[count]}, ptrtostore, elem});
     count++;
@@ -286,7 +286,7 @@ std::pair<optvalptr, mir::blockptr> ExprKnormVisitor::genIfBlock(ast::ExprPtr& b
                                                                  std::string const& label) {
   auto realblock = rv::holds_alternative<ast::Block>(*block)
                        ? rv::get<ast::Block>(*block)
-                       : ast::Block{ast::DebugInfo{}, {}, block};
+                       : ast::Block{{ast::DebugInfo{}}, {}, block};
   return mirgen.generateBlock(realblock, label, this->fnctx);
 }
 

--- a/src/compiler/mirgenerator.hpp
+++ b/src/compiler/mirgenerator.hpp
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #pragma once
+#include <utility>
+
 #include "basic/mir.hpp"
 #include "compiler/ffi.hpp"
 #include "compiler/type_infer_visitor.hpp"
@@ -16,7 +18,7 @@ class MirGenerator {
   struct ExprKnormVisitor : public VisitorBase<mir::valueptr&> {
     explicit ExprKnormVisitor(MirGenerator& parent, mir::blockptr block,
                               const std::optional<mir::valueptr>& fnctx)
-        : mirgen(parent), block(block), fnctx(fnctx) {}
+        : mirgen(parent), fnctx(fnctx), block(std::move(block)) {}
     mir::valueptr operator()(ast::Op& ast);
     mir::valueptr operator()(ast::Number& ast);
     mir::valueptr operator()(ast::String& ast);
@@ -68,9 +70,9 @@ class MirGenerator {
   };
   struct StatementKnormVisitor {
     explicit StatementKnormVisitor(ExprKnormVisitor& evisitor)
-        : exprvisitor(evisitor),
+        : retvalue(std::nullopt),
+          exprvisitor(evisitor),
           mirgen(evisitor.mirgen),
-          retvalue(std::nullopt),
           fnctx(exprvisitor.fnctx) {}
 
     void operator()(ast::Assign& ast);

--- a/src/compiler/symbolrenamer.cpp
+++ b/src/compiler/symbolrenamer.cpp
@@ -16,7 +16,7 @@ AstPtr SymbolRenamer::rename(ast::Statements& ast) {
   for (const auto& statement : ast) {
     newast->push_back(std::visit(statement_renamevisitor, *statement));
   }
-  return std::move(newast);
+  return newast;
 }
 
 std::string SymbolRenamer::getNewName(std::string const& name) {
@@ -37,14 +37,14 @@ using ExprRenameVisitor = SymbolRenamer::ExprRenameVisitor;
 
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Op& ast) {
   auto lhs = ast.lhs ? std::optional(rename(ast.lhs.value())) : std::nullopt;
-  return ast::makeExpr(ast::Op{ast.debuginfo, ast.op, lhs, rename(ast.rhs)});
+  return ast::makeExpr(ast::Op{{{ast.debuginfo}}, ast.op, lhs, rename(ast.rhs)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Number& ast) { return ast::makeExpr(ast); }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::String& ast) {
-  return ast::makeExpr(ast::String{ast.debuginfo, ast.value});
+  return ast::makeExpr(ast::String{{{ast.debuginfo}, ast.value}});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Symbol& ast) {
-  return ast::makeExpr(ast::Symbol{ast.debuginfo, renamer.searchFromEnv(ast.value)});
+  return ast::makeExpr(ast::Symbol{{{ast.debuginfo}}, renamer.searchFromEnv(ast.value)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Self& ast) { return ast::makeExpr(ast); }
 ast::Block SymbolRenamer::renameBlock(ast::Block& ast) {
@@ -52,7 +52,7 @@ ast::Block SymbolRenamer::renameBlock(ast::Block& ast) {
   auto newstmts = rename(ast.stmts);
   auto newexpr = ast.expr.has_value() ? std::optional(renameExpr(ast.expr.value())) : std::nullopt;
   env = env->parent_env;
-  return ast::Block{{ast.debuginfo}, *std::move(newstmts), std::move(newexpr)};
+  return ast::Block{{{ast.debuginfo}}, *std::move(newstmts), std::move(newexpr)};
 }
 
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Block& ast) {
@@ -61,14 +61,14 @@ ast::ExprPtr ExprRenameVisitor::operator()(ast::Block& ast) {
 ast::LambdaArgs ExprRenameVisitor::renameLambdaArgs(ast::LambdaArgs& ast) {
   auto newargs = ast::transformArgs(
       ast.args, [&](ast::DeclVar a) { return renamer.lvar_renamevisitor.renameDeclVar(a); });
-  return ast::LambdaArgs{ast.debuginfo, std::move(newargs)};
+  return ast::LambdaArgs{{{ast.debuginfo}}, std::move(newargs)};
 }
 ast::Lambda ExprRenameVisitor::renameLambda(ast::Lambda& ast) {
   renamer.env = renamer.env->expand();
   auto newargsast = renameLambdaArgs(ast.args);
   auto newbody = renamer.renameBlock(ast.body);
   renamer.env = renamer.env->parent_env;
-  return ast::Lambda{ast.debuginfo, std::move(newargsast), std::move(newbody), ast.ret_type};
+  return ast::Lambda{{{ast.debuginfo}}, std::move(newargsast), std::move(newbody), ast.ret_type};
 }
 
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Lambda& ast) {
@@ -77,20 +77,20 @@ ast::ExprPtr ExprRenameVisitor::operator()(ast::Lambda& ast) {
 
 ast::FcallArgs SymbolRenamer::renameFcallArgs(ast::FcallArgs& ast) {
   auto newargs = ast::transformArgs(ast.args, [&](ast::ExprPtr e) { return renameExpr(e); });
-  return ast::FcallArgs{ast.debuginfo, std::move(newargs)};
+  return ast::FcallArgs{{{ast.debuginfo}}, std::move(newargs)};
 }
 
 ast::Fcall SymbolRenamer::renameFcall(ast::Fcall& ast) {
   auto newargs = renameFcallArgs(ast.args);
   auto newfn = renameExpr(ast.fn);
-  return ast::Fcall{ast.debuginfo, std::move(newfn), std::move(newargs)};
+  return ast::Fcall{{{ast.debuginfo}}, std::move(newfn), std::move(newargs)};
 }
 ast::If SymbolRenamer::renameIf(ast::If& ast) {
   auto newcond = renameExpr(ast.cond);
   auto newthen = renameExpr(ast.then_stmts);
   auto newelse =
       ast.else_stmts.has_value() ? std::optional(renameExpr(ast.else_stmts.value())) : std::nullopt;
-  return ast::If{ast.debuginfo, newcond, newthen, newelse};
+  return ast::If{{{ast.debuginfo}}, newcond, newthen, newelse};
 }
 
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Fcall& ast) {
@@ -100,23 +100,23 @@ ast::ExprPtr ExprRenameVisitor::operator()(ast::Fcall& ast) {
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Struct& ast) {
   auto newargs =
       ast::transformArgs(ast.args, [&](ast::ExprPtr e) { return renamer.renameExpr(e); });
-  return ast::makeExpr(ast::Struct{ast.debuginfo, std::move(newargs)});
+  return ast::makeExpr(ast::Struct{{{ast.debuginfo}}, std::move(newargs)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::StructAccess& ast) {
-  return ast::makeExpr(ast::StructAccess{ast.debuginfo, rename(ast.stru), rename(ast.field)});
+  return ast::makeExpr(ast::StructAccess{{{ast.debuginfo}}, rename(ast.stru), rename(ast.field)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::ArrayInit& ast) {
   auto newargs =
       ast::transformArgs(ast.args, [&](ast::ExprPtr e) { return renamer.renameExpr(e); });
-  return ast::makeExpr(ast::ArrayInit{ast.debuginfo, std::move(newargs)});
+  return ast::makeExpr(ast::ArrayInit{{{ast.debuginfo}}, std::move(newargs)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::ArrayAccess& ast) {
-  return ast::makeExpr(ast::ArrayAccess{ast.debuginfo, rename(ast.array), rename(ast.index)});
+  return ast::makeExpr(ast::ArrayAccess{{{ast.debuginfo}}, rename(ast.array), rename(ast.index)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Tuple& ast) {
   auto newargs =
       ast::transformArgs(ast.args, [&](ast::ExprPtr e) { return renamer.renameExpr(e); });
-  return ast::makeExpr(ast::Tuple{ast.debuginfo, std::move(newargs)});
+  return ast::makeExpr(ast::Tuple{{{ast.debuginfo}}, std::move(newargs)});
 }
 
 ast::ExprPtr ExprRenameVisitor::operator()(ast::If& ast) {
@@ -127,40 +127,40 @@ using LvarRenameVisitor = SymbolRenamer::LvarRenameVisitor;
 ast::DeclVar LvarRenameVisitor::renameDeclVar(ast::DeclVar& ast) {
   auto newname = renamer.getNewName(ast.value.value);
   renamer.env->addToMap(ast.value.value, newname);
-  return ast::DeclVar{ast.debuginfo, ast::Symbol{ast.value.debuginfo, newname}, ast.type};
+  return ast::DeclVar{{{ast.debuginfo}}, ast::Symbol{{ast.value.debuginfo}, newname}, ast.type};
 }
 
 ast::Lvar LvarRenameVisitor::operator()(ast::DeclVar& ast) { return renameDeclVar(ast); }
 
 ast::Lvar LvarRenameVisitor::operator()(ast::ArrayLvar& ast) {
-  return ast::ArrayLvar{ast.debuginfo, renamer.renameExpr(ast.array),
-                        renamer.renameExpr(ast.index)};
+  return ast::ArrayLvar{
+      {{ast.debuginfo}}, renamer.renameExpr(ast.array), renamer.renameExpr(ast.index)};
 }
 ast::Lvar LvarRenameVisitor::operator()(ast::TupleLvar& ast) {
   auto newargs = ast::transformArgs(
       ast.args, [&](ast::DeclVar a) { return renamer.lvar_renamevisitor.renameDeclVar(a); });
-  return ast::TupleLvar{ast.debuginfo, newargs};
+  return ast::TupleLvar{{{ast.debuginfo}}, newargs};
 }
 using StatementRenameVisitor = SymbolRenamer::StatementRenameVisitor;
 
 StatementPtr StatementRenameVisitor::operator()(ast::Fdef& ast) {
   auto newlvar = renamer.lvar_renamevisitor.renameDeclVar(ast.lvar);
   auto newfun = renamer.expr_renamevisitor.renameLambda(ast.fun);
-  return ast::makeStatement(ast::Fdef{ast.debuginfo, std::move(newlvar), std::move(newfun)});
+  return ast::makeStatement(ast::Fdef{{{ast.debuginfo}}, std::move(newlvar), std::move(newfun)});
 }
 
 StatementPtr StatementRenameVisitor::operator()(ast::Assign& ast) {
   auto newlvar = renamer.renameLvar(ast.lvar);
   auto newrvar = renamer.renameExpr(ast.expr);
-  return ast::makeStatement(ast::Assign{ast.debuginfo, std::move(newlvar), std::move(newrvar)});
+  return ast::makeStatement(ast::Assign{{{ast.debuginfo}}, std::move(newlvar), std::move(newrvar)});
 }
 StatementPtr StatementRenameVisitor::operator()(ast::Return& ast) {
-  return ast::makeStatement(ast::Return{ast.debuginfo, renamer.renameExpr(ast.value)});
+  return ast::makeStatement(ast::Return{{{ast.debuginfo}}, renamer.renameExpr(ast.value)});
 }
 // StatementPtr StatementRenameVisitor::operator()(ast::Declaration& ast) {}
 StatementPtr StatementRenameVisitor::operator()(ast::Time& ast) {
   return ast::makeStatement(
-      ast::Time{ast.debuginfo, renamer.renameFcall(ast.fcall), renamer.renameExpr(ast.when)});
+      ast::Time{{{ast.debuginfo}}, renamer.renameFcall(ast.fcall), renamer.renameExpr(ast.when)});
 }
 StatementPtr StatementRenameVisitor::operator()(ast::Fcall& ast) {
   return ast::makeStatement(renamer.renameFcall(ast));
@@ -176,7 +176,7 @@ StatementPtr StatementRenameVisitor::operator()(ast::For& ast) {
   auto newstmts = renamer.renameBlock(ast.statements);
   renamer.env = renamer.env->parent_env;
   return ast::makeStatement(
-      ast::For{ast.debuginfo, std::move(newindex), std::move(newiter), std::move(newstmts)});
+      ast::For{{{ast.debuginfo}}, std::move(newindex), std::move(newiter), std::move(newstmts)});
 }
 
 }  // namespace mimium

--- a/src/compiler/type_infer_visitor.cpp
+++ b/src/compiler/type_infer_visitor.cpp
@@ -15,8 +15,8 @@ types::Value ExprTypeVisitor::operator()(ast::Op& ast) {
   return ast.lhs.has_value() ? inferer.unify(infer(ast.lhs.value()), infer(ast.rhs))
                              : infer(ast.rhs);
 }
-types::Value ExprTypeVisitor::operator()(ast::Number& ast) { return types::Float{}; }
-types::Value ExprTypeVisitor::operator()(ast::String& ast) { return types::String{}; }
+types::Value ExprTypeVisitor::operator()(ast::Number&  /*ast*/) { return types::Float{}; }
+types::Value ExprTypeVisitor::operator()(ast::String&  /*ast*/) { return types::String{}; }
 types::Value ExprTypeVisitor::operator()(ast::Symbol& ast) {
   return inferer.typeenv.find(ast.value);
 }
@@ -178,7 +178,7 @@ types::Value StatementTypeVisitor::operator()(ast::Time& ast) {
 
 types::Value TypeInferer::addDeclVar(ast::DeclVar& lvar) {
   auto res = lvar.type.value_or(*typeenv.createNewTypeVar());
-  auto [iter, was_newvar] = typeenv.emplace(lvar.value.value, res);
+  typeenv.emplace(lvar.value.value, res);
   return res;
 }
 
@@ -237,9 +237,10 @@ types::Value TypeUnifyVisitor::unify(types::rStruct s1, types::rStruct s2) {
   // TODO(tomoya)
   return s1;
 }
-types::Value TypeUnifyVisitor::unify(types::rTuple f1, types::rTuple f2) {
-  // TODO(tomoya)
-  return f1;
+types::Value TypeUnifyVisitor::unify(types::rTuple t1, types::rTuple t2) {
+  auto lhs = t1.getraw();
+  auto rhs = t2.getraw();
+  return types::Tuple{unifyArgs(lhs.arg_types, rhs.arg_types)};
 }
 std::vector<types::Value> TypeUnifyVisitor::unifyArgs(std::vector<types::Value>& v1,
                                                       std::vector<types::Value>& v2) {
@@ -268,7 +269,7 @@ TypeEnv& TypeInferer::infer(ast::Statements& topast) {
 }
 void TypeInferer::substituteTypeVars() {
   for (auto&& [key, t] : typeenv.env) {
-    auto [iter, replaced] = typeenv.env.insert_or_assign(key, std::visit(substitutevisitor, t));
+    typeenv.env.insert_or_assign(key, std::visit(substitutevisitor, t));
   }
 }
 

--- a/src/frontend/cli.cpp
+++ b/src/frontend/cli.cpp
@@ -80,7 +80,7 @@ Debug Informations (if no output file specified, emit to stdout.)
 std::vector<std::string_view> CliApp::OptionParser::initRawArgs(int argc, char** argv) {
   std::vector<std::string_view> args;
   args.resize(argc);
-  for (int idx = 0; idx < argc; idx++) { args[idx] = argv[idx]; }
+  for (int idx = 0; idx < argc; idx++) { args[idx] = argv[idx]; }//NOLINT
   return args;
 }
 

--- a/src/frontend/cli.hpp
+++ b/src/frontend/cli.hpp
@@ -55,4 +55,4 @@ class CliApp {
   CliAppMode mode = CliAppMode::Run;
 };
 
-}  // namespace mimium::cl
+}  // namespace mimium::app::cli

--- a/src/frontend/genericapp.cpp
+++ b/src/frontend/genericapp.cpp
@@ -167,7 +167,6 @@ int GenericApp::run() {
     int res = 0;
     if (should_run) {
       auto backend = std::make_unique<AudioDriverRtAudio>();
-      bool optimize = option->runtime_option.optimize_level == OptimizeLevel::ON;
       res = runtimeMainLoop(option->runtime_option, option->input.value().filepath,
                             option->input.value().filetype, option->output_path);
     }

--- a/src/frontend/genericapp.hpp
+++ b/src/frontend/genericapp.hpp
@@ -4,18 +4,8 @@
 
 #pragma once
 #include <csignal>
-#include <functional>
-#include <iostream>
-#include <memory>
 #include "../libmain.hpp"
 #include "basic/filereader.hpp"
-
-#include <csignal>
-#include <filesystem>
-#include <fstream>
-#include <string>
-namespace fs = std::filesystem;
-
 namespace mimium::app {
 
 

--- a/src/preprocessor/preprocessor.hpp
+++ b/src/preprocessor/preprocessor.hpp
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-
-#pragma one
+#pragma once
 #include <list>
 #include <unordered_set>
 #include "basic/filereader.hpp"

--- a/src/runtime/JIT/jit_engine.hpp
+++ b/src/runtime/JIT/jit_engine.hpp
@@ -149,4 +149,4 @@ class MimiumJIT {
   [[nodiscard]] const DataLayout& getDataLayout() const { return DL; }
   LLVMContext& getContext() { return *Ctx.getContext(); }
 };
-}  // namespace llvm
+}  // namespace llvm::orc

--- a/src/runtime/JIT/runtime_jit.cpp
+++ b/src/runtime/JIT/runtime_jit.cpp
@@ -12,7 +12,7 @@ void setDspParams(void* runtimeptr, void* dspfn, void* clsaddress, void* memobja
   auto* runtime = static_cast<mimium::Runtime*>(runtimeptr);
   auto& audiodriver = runtime->getAudioDriver();
   auto p = std::make_unique<mimium::DspFnInfos>(mimium::DspFnInfos{
-      reinterpret_cast<mimium::DspFnPtr>(dspfn), clsaddress, memobjaddress, in_numchs, out_numchs});
+      reinterpret_cast<mimium::DspFnPtr>(dspfn), clsaddress, memobjaddress, in_numchs, out_numchs});//NOLINT
   audiodriver.setDspFnInfos(std::move(p));
 }
 
@@ -43,15 +43,15 @@ void* mimium_malloc(void* runtimeptr, size_t size) {
 
 namespace mimium {
 Runtime_LLVM::Runtime_LLVM(std::unique_ptr<llvm::LLVMContext> ctx,
-                           std::unique_ptr<llvm::Module> module, std::string const& filename_i,
+                           std::unique_ptr<llvm::Module> module, std::string const&  /*filename_i*/,
                            std::unique_ptr<AudioDriver> a, bool optimize)
-    : Runtime(filename_i, std::move(a)), module(std::move(module)) {
+    : Runtime(std::move(a)), module(std::move(module)) {
   init(std::move(ctx), optimize);
 }
 
 Runtime_LLVM::Runtime_LLVM(std::string const& filepath, std::unique_ptr<AudioDriver> a,
                            bool optimize)
-    : Runtime(filepath, std::move(a)) {
+    : Runtime(std::move(a)) {
   auto ctx = std::make_unique<llvm::LLVMContext>();
   llvm::SMDiagnostic errorreporter;
   module = llvm::parseIRFile(filepath, errorreporter, *ctx);

--- a/src/runtime/JIT/runtime_jit.hpp
+++ b/src/runtime/JIT/runtime_jit.hpp
@@ -15,15 +15,15 @@ class Runtime_LLVM : public Runtime, public std::enable_shared_from_this<Runtime
                         std::unique_ptr<AudioDriver> a = nullptr, bool optimize = true);
   explicit Runtime_LLVM(std::string const& filepath, std::unique_ptr<AudioDriver> a = nullptr,
                         bool optimize = true);
-  ~Runtime_LLVM() = default;
+  ~Runtime_LLVM() override = default;
   void start() override;
   void runMainFun() override;
-  
+
   auto& getJitEngine() { return *jitengine; }
   llvm::LLVMContext& getLLVMContext() { return jitengine->getContext(); }
 
  private:
- //called by constructor.
+  // called by constructor.
   void init(std::unique_ptr<llvm::LLVMContext> ctx, bool optimize);
   std::unique_ptr<llvm::Module> module;
   std::unique_ptr<llvm::orc::MimiumJIT> jitengine;

--- a/src/runtime/runtime.hpp
+++ b/src/runtime/runtime.hpp
@@ -14,7 +14,7 @@ class AudioDriver;
 
 class Runtime {
  public:
-  explicit Runtime(std::string const& filename_i = "untitled",std::unique_ptr<AudioDriver> a=nullptr):audiodriver(std::move(a))  {}
+  explicit Runtime(std::unique_ptr<AudioDriver> a=nullptr):audiodriver(std::move(a))  {}
 
   virtual ~Runtime() {
     for (auto&& [address, size] : malloc_container) { free(address); }
@@ -23,8 +23,8 @@ class Runtime {
   virtual void runMainFun()=0;
   virtual void start() = 0;
   auto& getAudioDriver() { return *audiodriver; }
-  bool hasDsp() { return hasdsp; }
-  bool hasDspCls() { return hasdspcls; }
+  [[nodiscard]] bool hasDsp() const { return hasdsp; }
+  [[nodiscard]] bool hasDspCls() const { return hasdspcls; }
   void push_malloc(void* address, size_t size) { malloc_container.emplace_back(address, size); }
 
  protected:

--- a/src/runtime/scheduler.cpp
+++ b/src/runtime/scheduler.cpp
@@ -26,13 +26,13 @@ void Scheduler::addTask(double time, void* addresstofn, double arg, void* addres
 
 void Scheduler::executeTask(const TaskType& task) {
   // todo
-  auto& [addresstofn, arg, addresstocls] = task;
+  const auto& [addresstofn, arg, addresstocls] = task;
 
   if (addresstocls == nullptr) {
-    auto fn = reinterpret_cast<void (*)(double)>(addresstofn);
+    auto fn = reinterpret_cast<void (*)(double)>(addresstofn);//NOLINT
     fn(arg);
   } else {
-    auto fn = reinterpret_cast<void (*)(double, void*)>(addresstofn);
+    auto fn = reinterpret_cast<void (*)(double, void*)>(addresstofn);//NOLINT
     fn(arg, addresstocls);
   }
   tasks.pop();
@@ -44,7 +44,7 @@ void Scheduler::executeTask(const TaskType& task) {
   }
 }
 
-void Scheduler::start(bool _hasdsp) { hasdsp = _hasdsp; }
+void Scheduler::start(bool hasdsp) { this->hasdsp = hasdsp; }
 
 void Scheduler::stop() {
   {

--- a/src/runtime/scheduler.hpp
+++ b/src/runtime/scheduler.hpp
@@ -20,10 +20,10 @@ struct TaskType {
 
 class Scheduler {  // scheduler interface
  public:
-  explicit Scheduler() : wc(), time(0) {}
+  explicit Scheduler() : wc() {}
 
   virtual ~Scheduler() = default;
-  virtual void start(bool _hasdsp);
+  virtual void start(bool hasdsp);
   virtual void stop();
 
   bool hasTask() { return !tasks.empty(); }
@@ -34,7 +34,7 @@ class Scheduler {  // scheduler interface
   // time,address to fun, arg(double), addresstoclosure,
   void addTask(double time, void* addresstofn, double arg, void* addresstocls);
 
-  //if dsp function exists
+  // if dsp function exists
   bool hasdsp = false;
   [[nodiscard]] auto getTime() const { return time; }
   auto& getWaitController() { return wc; }

--- a/test/0.newast_test.cpp
+++ b/test/0.newast_test.cpp
@@ -1,14 +1,14 @@
 #include "basic/ast.hpp"
 #include "gtest/gtest.h"
-#include "gtest/internal/gtest-port.h"
+#include "gtest/internal/gtest-port.h" 
 namespace mimium {
 
-TEST(newast, basic) {
+TEST(newast, basic) {//NOLINT
   ast::DebugInfo dbg;
   ast::Number num1 = {{dbg}, 1};
-  auto numptr = makeExpr(ast::Number{dbg, 1});
-  auto strptr = makeExpr(ast::String{dbg, "test!"});
-  ast::String str = {dbg, "test"};
+  auto numptr = makeExpr(ast::Number{{dbg}, 1});
+  auto strptr = makeExpr(ast::String{{{dbg},"test!"}});
+  ast::String str{{{dbg}, "test"}};
   ast::Op opast = {{dbg}, ast::OpId::Add, numptr, strptr};
   auto variant = *opast.lhs.value();
   EXPECT_TRUE(std::holds_alternative<ast::Number>(variant));
@@ -18,11 +18,11 @@ TEST(newast, basic) {
   std::string str_target = "test!";
   EXPECT_EQ(str_answer, str_target);
 }
-TEST(newast, statement) {
+TEST(newast, statement) {//NOLINT
   ast::DebugInfo dbg;
   auto statement = ast::makeStatement(
-      ast::Assign{dbg, ast::DeclVar{dbg, ast::Symbol{dbg, "leftvar"}, types::Float{}},
-                  ast::makeExpr(ast::Number{dbg, 1})});
+      ast::Assign{{dbg}, ast::DeclVar{{dbg}, ast::Symbol{{dbg}, "leftvar"}, types::Float{}},
+                  ast::makeExpr(ast::Number{{dbg}, 1})});
   EXPECT_TRUE(std::holds_alternative<ast::Assign>(*statement));
   // EXPECT_EQ(std::get<ast::Assign>(*statement).lvar.type.value() ,types::Value(types::Float{}));
 }

--- a/test/1.ast_to_string_test.cpp
+++ b/test/1.ast_to_string_test.cpp
@@ -6,10 +6,12 @@
 #include "gtest/internal/gtest-port.h"
 namespace mimium {
 
-TEST(asttostring, basic) {
+TEST(asttostring, basic) {//NOLINT
   ast::DebugInfo dbg;
   auto statement = ast::makeStatement(ast::Assign{
-      dbg, ast::DeclVar{dbg, ast::Symbol{dbg,"hoge"}, std::optional(types::Float{})}, ast::makeExpr(ast::Number{dbg, 1})});
+      {{dbg}},
+      ast::DeclVar{{{dbg}}, ast::Symbol{{{dbg}}, "hoge"}, std::optional(types::Float{})},
+      ast::makeExpr(ast::Number{{{dbg}}, 1})});
   std::ostringstream ss;
   ss << *statement;
   std::string target("(assign (lvar hoge float) 1)");

--- a/test/2.parser_test.cpp
+++ b/test/2.parser_test.cpp
@@ -4,11 +4,11 @@
 #include "gtest/gtest.h"
 #include "gtest/internal/gtest-port.h"
 namespace mimium {
-
-#define PARSER_TEST(FILENAME)                                             \
-  TEST(parser, FILENAME) {                                                \
-    Driver driver{};                                                      \
-    ast::Statements& ast = *driver.parseFile( TEST_ROOT_DIR "/parser/" #FILENAME ".mmm"); \
+// NOLINTNEXTLINE
+#define PARSER_TEST(FILENAME)                                     \
+  TEST(parser, FILENAME) { /*NOLINT*/                             \
+    Driver driver{};                                              \
+    *driver.parseFile(TEST_ROOT_DIR "/parser/" #FILENAME ".mmm"); \
   }
 
 PARSER_TEST(operators)
@@ -26,10 +26,9 @@ PARSER_TEST(tuplelvar)
 PARSER_TEST(tuple)
 PARSER_TEST(tupletype)
 
-
-TEST(parser, ast_complete) {
+TEST(parser, ast_complete) {//NOLINT
   Driver driver{};
-  auto ast = driver.parseFile( TEST_ROOT_DIR "/ast_complete.mmm");
+  auto ast = driver.parseFile(TEST_ROOT_DIR "/ast_complete.mmm");
   // std::cerr << ast << "\n";
 }
 

--- a/test/3.symbolrename_test.cpp
+++ b/test/3.symbolrename_test.cpp
@@ -5,7 +5,7 @@
 #include "gtest/internal/gtest-port.h"
 
 namespace mimium {
-TEST(symbolrename, astcomplete) {
+TEST(symbolrename, astcomplete) {//NOLINT
   Driver driver{};
   auto ast = driver.parseFile(TEST_ROOT_DIR "/ast_complete.mmm");
   SymbolRenamer renamer;

--- a/test/4.typeinfer_test.cpp
+++ b/test/4.typeinfer_test.cpp
@@ -12,19 +12,19 @@
   auto newast = renamer.rename(ast);                                                          \
   TypeInferer inferer;
 namespace mimium {
-TEST(typeinfer, float_success) {
+TEST(typeinfer, float_success) {//NOLINT
   PREP(float_success)
   EXPECT_TRUE(std::holds_alternative<types::Float>(inferer.infer(*newast).env.at("hoge0")));
 }
-TEST(typeinfer, float_infer) {
+TEST(typeinfer, float_infer) {//NOLINT
   PREP(float_infer)
   EXPECT_TRUE(std::holds_alternative<types::Float>(inferer.infer(*newast).env.at("hoge0")));
 }
-TEST(typeinfer, float_failure) {
+TEST(typeinfer, float_failure) {//NOLINT
   PREP(float_failure)
-  EXPECT_THROW(auto a = inferer.infer(*newast);, std::runtime_error);
+  EXPECT_THROW(auto a = inferer.infer(*newast);, std::runtime_error);//NOLINT
 }
-TEST(typeinfer, function) {
+TEST(typeinfer, function) {//NOLINT
   PREP(function)
   auto& env = inferer.infer(*newast).env;
   auto& add = env.at("add0");
@@ -49,7 +49,7 @@ TEST(typeinfer, function) {
                types::Function{types::Float{}, {types::Float{}, types::Float{}, types::Float{}}}));
   EXPECT_TRUE(std::holds_alternative<types::Float>(res));
 }
-TEST(typeinfer, highorderfunction) {
+TEST(typeinfer, highorderfunction) {//NOLINT
   PREP(highorderfunction)
   auto& env = inferer.infer(*newast).env;
   auto& add = env.at("add0");
@@ -69,22 +69,22 @@ TEST(typeinfer, highorderfunction) {
   EXPECT_TRUE(std::holds_alternative<types::Float>(env.at("result7")));
 }
 
-TEST(typeinfer, recursivecall) {
+TEST(typeinfer, recursivecall) {//NOLINT
   PREP(recursivecall)
   auto& env = inferer.infer(*newast).env;
   EXPECT_TRUE((rv::get<types::Function>(env.at("fact0")) ==
                types::Function{types::Float{}, {types::Float{}}}));
 }
-TEST(typeinfer, self) {
+TEST(typeinfer, self) {//NOLINT
   PREP(self)
   auto& env = inferer.infer(*newast).env;
   EXPECT_TRUE((rv::get<types::Function>(env.at("lowpass0")) ==
                types::Function{types::Float{}, {types::Float{}, types::Float{}}}));
 }
 
-TEST(typeinfer, occurfail) {
+TEST(typeinfer, occurfail) {//NOLINT
   PREP(occur_failure)
-  EXPECT_THROW(auto a = inferer.infer(*newast);, std::runtime_error);
+  EXPECT_THROW(auto a = inferer.infer(*newast);, std::runtime_error);//NOLINT
 }
 
 }  // namespace mimium

--- a/test/5.mirgen_test.cpp
+++ b/test/5.mirgen_test.cpp
@@ -15,7 +15,7 @@
   auto& env = inferer.infer(*newast);                         \
   MirGenerator mirgenerator(env);
 
-TEST(mirgen, basic) {
+TEST(mirgen, basic) {//NOLINT
   PREP(test_localvar)
   auto mir = mirgenerator.generate(*newast);
   std::string target = R"(root:

--- a/test/preprocessor_test.cpp
+++ b/test/preprocessor_test.cpp
@@ -7,7 +7,7 @@ namespace fs = std::filesystem;
 #define TEST_ROOT_DIR "\"\""
 #endif
 
-TEST(preprocessor, include) {
+TEST(preprocessor, include) {//NOLINT
   fs::path root = TEST_ROOT_DIR;
   fs::path pptest_path = root / "preprocessor";
   fs::path includer = pptest_path / "includer.mmm";

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -12,9 +12,9 @@ namespace fs = std::filesystem;
 #ifndef TEST_BIN_DIR
 #define TEST_BIN_DIR ""
 #endif
-
+// NOLINTNEXTLINE
 #define REGRESSION(filename, expect)                                                          \
-  TEST(regression, filename) {                                                                \
+  TEST(regression, filename) { /*NOLINT*/                                                     \
     testing::internal::CaptureStdout();                                                       \
     fs::path testbinpath(TEST_BIN_DIR);                                                       \
     fs::current_path(testbinpath);                                                            \
@@ -73,7 +73,6 @@ REGRESSION(builtin,
 )")
 
 REGRESSION(libsndfile, "146640\n-0.0803833\n")
-
 
 REGRESSION(tuple_capture, "100\n200\n300\n")
 REGRESSION(tupletofn, "0.2\n0.8\n0.6\n2.4\n")


### PR DESCRIPTION
As `-Wall` compiler option was disabled for a while in my environment, fixed many warnings suggested by clang.