### PR TITLE
Feat primitive mem

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,8 +70,11 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE=1 brew install flex bison libsndfile llvm ninja
       - if: contains(matrix.os, 'ubuntu')
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install llvm
-          sudo apt-get update
+          brew update
+          brew info llvm@11
+      - if: contains(matrix.os, 'ubuntu')
+        run: |
+          brew install llvm@11
           sudo apt-get install libalsa-ocaml-dev libfl-dev libbison-dev libz-dev libsndfile-dev libopus-dev gcc-9 ninja-build
       - uses: actions/checkout@v2
         with: 

--- a/cmake/FindLlvm.cmake
+++ b/cmake/FindLlvm.cmake
@@ -16,16 +16,19 @@ find_path(LLVM_INCLUDE_DIRS NAMES llvm/IR/IRBuilder.h
     ${HOMEBREW_PATH}/include
     ${HOMEBREW_PATH}/opt/llvm/include
     /usr/local/opt/llvm/include
+    /usr/local/include
+    /usr/include
     /mingw64/include
     C:/tools/msys64/mingw64/include
 )
 find_program(LLVM_CONFIG_EXE
-      NAMES llvm-config llvm-config-10 llvm-config10
+      NAMES llvm-config llvm-config-11 llvm-config11
       PATHS
       ${HOMEBREW_PATH}/bin
       ${HOMEBREW_PATH}/opt/llvm/bin
-      /usr/local/bin
       /usr/local/opt/llvm/bin
+      /usr/local/bin
+      /usr/bin
       "/mingw64/bin"
       "/c/msys64/mingw64/bin"
       "C:/tools/msys64/mingw64/bin"
@@ -73,7 +76,12 @@ find_program(LLVM_CONFIG_EXE
   NEED_TARGET("WebAssembly")
   NEED_TARGET("X86")
   # NEED_TARGET("XCore")
-
+  if((NOT LLVM_INCLUDE_DIRS))
+  execute_process(
+    COMMAND ${LLVM_CONFIG_EXE} --includedir
+    OUTPUT_VARIABLE LLVM_INCLUDE_DIRS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  endif()
   
   if(NOT LLVM_LIBRARIES)
     execute_process(

--- a/src/basic/ast.hpp
+++ b/src/basic/ast.hpp
@@ -246,4 +246,4 @@ auto makeStatement(FROM&& ast) {
   return std::make_shared<ast::Statement>(ast);
 }
 
-}  // namespace mimium
+}  // namespace mimium::ast

--- a/src/compiler/codegen/llvmgenerator.cpp
+++ b/src/compiler/codegen/llvmgenerator.cpp
@@ -88,6 +88,7 @@ llvm::Function* LLVMGenerator::getForeignFunction(const std::string& name) {
   const auto& [type, targetname] = LLVMBuiltin::ftable.find(name)->second;
   auto ftype = rv::get<types::Function>(type);
   if (name == "delay") { ftype.arg_types.emplace_back(types::Ref{types::getDelayStruct()}); }
+  if (name == "mem") { ftype.arg_types.emplace_back(types::Ref{types::Float{}}); }
   if (!types::isPrimitive(ftype.ret_type)) {
     // for loadwavfile
     ftype.ret_type = types::Ref{ftype.ret_type};

--- a/src/compiler/collect_memoryobjs.cpp
+++ b/src/compiler/collect_memoryobjs.cpp
@@ -175,6 +175,12 @@ ResultT MemoryObjsCollector::CollectMemVisitor::operator()(minst::Fcall& i) {
                                 M.result_map.emplace(i.fname, res);
                                 return res;
                               }
+                              if(e.name == "mem"){
+                                auto res = std::make_shared<FunObjTree>(
+                                    FunObjTree{i.fname, false, {}, types::Float{}});
+                                M.result_map.emplace(i.fname, res);
+                                return res;
+                              }
                               return std::nullopt;
                             },
                             [&](std::shared_ptr<mir::Argument> e) -> opt_objtreeptr {

--- a/src/compiler/collect_memoryobjs.hpp
+++ b/src/compiler/collect_memoryobjs.hpp
@@ -82,7 +82,9 @@ class MemoryObjsCollector {
 
    private:
     static bool isSelf(mir::valueptr val) { return std::holds_alternative<mir::Self>(*val); };
-    static bool isExternalFunMemobj(const mir::ExternalSymbol& s) { return s.name == "delay"; }
+    static bool isExternalFunMemobj(const mir::ExternalSymbol& s) {
+      return s.name == "delay" || s.name == "mem";
+    }
     static ResultT makeResfromHasSelf(bool hasself);
     static void mergeResultTs(ResultT& dest, ResultT& src);
   };

--- a/src/compiler/ffi.cpp
+++ b/src/compiler/ffi.cpp
@@ -49,6 +49,12 @@ struct MmmRingBuf {
   int64_t writei = 0;
   double buf[mimium::types::fixed_delaysize]{};
 };
+
+MIMIUM_DLL_PUBLIC double mimium_memprim(double in, double* valptr){
+  auto res= *valptr;
+  *valptr = in;
+  return res;
+}
 MIMIUM_DLL_PUBLIC double mimium_delayprim(double in, double time, MmmRingBuf* rbuf) {
   auto size = sizeof(rbuf->buf) / sizeof(double);
   rbuf->writei = (rbuf->writei + 1) % size;

--- a/test/mmm/test_mem.mmm
+++ b/test/mmm/test_mem.mmm
@@ -25,6 +25,7 @@ fn adsr(attack,decay,sustain,release,input){
     return if (at_or_rel) at_dec_sus_sig else releasesig
 }
 
-fn dsp(time){
-    return sin(time/10) * adsr(0.1,0.2,0.1,0.1, stepinout(time,44100,120000))
+fn dsp(){
+    out = sin(now/10) * adsr(0.1,0.2,0.1,0.1, stepinout(now,44100,120000))
+    return (out,out)
 }


### PR DESCRIPTION
This pr adds a new primitive function `mem`, 1-sample delay.
`mem` function is more efficient in terms of memory space than `delay` function.
See `test/mmm/test_mem.mmm`