### PR TITLE
Fix code generation of if statement with void type block

### DIFF
--- a/src/compiler/codegen/codegen_visitor.cpp
+++ b/src/compiler/codegen/codegen_visitor.cpp
@@ -539,14 +539,11 @@ llvm::Value* CodeGenVisitor::operator()(minst::Field& i) {
 
 llvm::Value* CodeGenVisitor::createIfBody(mir::blockptr& block) {
   auto& insts = block->instructions;
-  if (!std::holds_alternative<minst::Return>(std::get<mir::Instructions>(*insts.back()))) {
-    throw std::logic_error("non-void block should have minst::Return for last line");
-  }
-  for (auto&& iter = insts.cbegin(); iter != std::prev(insts.cend()); ++iter) {
-    G.visitInstructions(*iter, false);
-  }
-  auto retinst = mir::getInstRef<minst::Return>(insts.back());
-  return getLlvmVal(retinst.val);
+  const bool hasreturn =
+      std::holds_alternative<minst::Return>(std::get<mir::Instructions>(*insts.back()));
+  const auto enditer = hasreturn ? std::prev(insts.cend()) : insts.cend();
+  for (auto&& iter = insts.cbegin(); iter != enditer; ++iter) { G.visitInstructions(*iter, false); }
+  return hasreturn ? getLlvmVal(mir::getInstRef<minst::Return>(insts.back()).val) : nullptr;
 }
 
 llvm::Value* CodeGenVisitor::operator()(minst::If& i) {
@@ -574,10 +571,10 @@ llvm::Value* CodeGenVisitor::operator()(minst::If& i) {
   bool isvoid = std::holds_alternative<types::Void>(ifrettype);
   llvm::Value* res = nullptr;
   if (!isvoid) {
+    assert(elseret != nullptr && thenret != nullptr);
     auto* phinode = G.builder->CreatePHI(G.getType(i.type), 2);
     phinode->addIncoming(thenret, thenbb_last);
     phinode->addIncoming(elseret, elsebb_last);
-
     res = phinode;
   }
   G.builder->SetInsertPoint(thisbb);

--- a/src/compiler/mirgenerator.cpp
+++ b/src/compiler/mirgenerator.cpp
@@ -117,7 +117,7 @@ mir::valueptr ExprKnormVisitor::operator()(ast::Symbol& ast) {
   }
   throw std::runtime_error("symbol " + ast.value + " not found");
 }  // namespace mimium
-mir::valueptr ExprKnormVisitor::operator()(ast::Self&  /*ast*/) {
+mir::valueptr ExprKnormVisitor::operator()(ast::Self& /*ast*/) {
   // todo: create special type for self
   MMMASSERT(fnctx.has_value(), "Self cannot used in global context");
   auto self = mir::Self{fnctx.value(), types::Float{}};
@@ -294,7 +294,7 @@ mir::valueptr ExprKnormVisitor::operator()(ast::If& ast) {
   auto lvname = mirgen.makeNewName();
   auto cond = genInst(ast.cond);
   auto [thenretval, thenblock] = genIfBlock(ast.then_stmts, lvname + "$then");
-  auto rettype = mir::getType(*require(thenretval));
+  auto rettype = thenretval.has_value() ? mir::getType(*require(thenretval)) : types::Void{};
   if (ast.else_stmts.has_value()) {
     auto [elseretval, elseblock] = genIfBlock(ast.else_stmts.value(), lvname + "$else");
     return emplace(minst::If{{lvname, rettype}, cond, thenblock, elseblock});

--- a/test/mmm/test_if_void.mmm
+++ b/test/mmm/test_if_void.mmm
@@ -1,0 +1,24 @@
+myglobal=0
+
+fn mutate(){
+    myglobal = myglobal+1
+}
+
+
+fn test(cond){
+    if(cond) mutate()
+    println(myglobal)
+}
+
+fn test2(cond){
+    if(cond){
+        mutate()
+        println(myglobal)
+    }else{
+        println(myglobal)
+    }
+}
+
+test(1)//print 1
+test2(1)//print 2
+test2(0)//print 2

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -36,6 +36,7 @@ REGRESSION(closure2, "20015\n")
 REGRESSION(tuple, "100\n")
 REGRESSION(fibonacchi, "610\n")
 REGRESSION(ifexpr, "130\n")
+REGRESSION(if_void,"1\n2\n2\n")
 REGRESSION(builtin,
            R"(100
 2.55255e+08


### PR DESCRIPTION
close #46
This PR fixes bug in code generation of if statement with void block such as an example shown below.
Thanks @syougikakugenn for reporting.

```rust
fn test2(cond){
    if(cond){
        mutate()
        println(myglobal)
    }else{
        println(myglobal)
    }
}
```
