### PR TITLE
fix/operator-eqneq

### DIFF
--- a/src/compiler/codegen/codegen_visitor.cpp
+++ b/src/compiler/codegen/codegen_visitor.cpp
@@ -13,10 +13,11 @@ using OpId = ast::OpId;
 const std::unordered_map<OpId, std::string> CodeGenVisitor::opid_to_ffi = {
     // names are declared in ffi.cpp
 
-    {OpId::Exponent, "pow"}, {OpId::Mod, "fmod"},       {OpId::GreaterEq, "ge"},
-    {OpId::LessEq, "le"},    {OpId::GreaterThan, "gt"}, {OpId::LessThan, "lt"},
-    {OpId::And, "and"},      {OpId::BitAnd, "and"},     {OpId::Or, "or"},
-    {OpId::BitOr, "or"},     {OpId::LShift, "lshift"},  {OpId::RShift, "rshift"},
+    {OpId::Exponent, "pow"},  {OpId::Mod, "fmod"},       {OpId::GreaterEq, "ge"},
+    {OpId::LessEq, "le"},     {OpId::GreaterThan, "gt"}, {OpId::LessThan, "lt"},
+    {OpId::Equal, "eq"},      {OpId::NotEq, "noteq"},    {OpId::And, "and"},
+    {OpId::BitAnd, "and"},    {OpId::Or, "or"},          {OpId::BitOr, "or"},
+    {OpId::LShift, "lshift"}, {OpId::RShift, "rshift"},
 };
 
 // Creates Allocation instruction or call malloc function depends on context

--- a/src/compiler/ffi.cpp
+++ b/src/compiler/ffi.cpp
@@ -21,6 +21,8 @@ MIMIUM_DLL_PUBLIC int64_t mimium_dtoi(double d) { return static_cast<int64_t>(d)
 MIMIUM_DLL_PUBLIC double mimium_gt(double d1, double d2) { return static_cast<double>(d1 > d2); }
 MIMIUM_DLL_PUBLIC double mimium_lt(double d1, double d2) { return static_cast<double>(d1 < d2); }
 MIMIUM_DLL_PUBLIC double mimium_ge(double d1, double d2) { return static_cast<double>(d1 >= d2); }
+MIMIUM_DLL_PUBLIC double mimium_eq(double d1, double d2) { return static_cast<double>(d1 == d2); }
+MIMIUM_DLL_PUBLIC double mimium_noteq(double d1, double d2) { return static_cast<double>(d1 != d2); }
 MIMIUM_DLL_PUBLIC double mimium_le(double d1, double d2) { return static_cast<double>(d1 <= d2); }
 MIMIUM_DLL_PUBLIC double mimium_and(double d1, double d2) {
   return static_cast<double>(mimium_dtob(d1) && mimium_dtob(d2));
@@ -129,6 +131,8 @@ const std::unordered_map<std::string, BuiltinFnInfo> LLVMBuiltin::ftable = {
     {"max", initBI(Function{Float{}, {Float{}, Float{}}}, "fmax")},
 
     {"ge", initBI(Function{Float{}, {Float{}, Float{}}}, "mimium_ge")},
+    {"eq", initBI(Function{Float{}, {Float{}, Float{}}}, "mimium_eq")},
+    {"noteq", initBI(Function{Float{}, {Float{}, Float{}}}, "mimium_noteq")},
     {"le", initBI(Function{Float{}, {Float{}, Float{}}}, "mimium_le")},
     {"gt", initBI(Function{Float{}, {Float{}, Float{}}}, "mimium_gt")},
     {"lt", initBI(Function{Float{}, {Float{}, Float{}}}, "mimium_lt")},

--- a/src/compiler/mimium.yy
+++ b/src/compiler/mimium.yy
@@ -386,6 +386,7 @@ op:   expr ADD    expr   {$$ = ast::Op{{@$,"op"},ast::OpId::Add,        std::mov
      |expr LE expr       {$$ = ast::Op{{@$,"op"},ast::OpId::LessEq,     std::move($1),std::move($3)};}
      |expr LSHIFT expr   {$$ = ast::Op{{@$,"op"},ast::OpId::LShift,     std::move($1),std::move($3)};}
      |expr RSHIFT expr   {$$ = ast::Op{{@$,"op"},ast::OpId::RShift,     std::move($1),std::move($3)};}
+     |expr EQ expr      {$$ = ast::Op{{@$,"op"},ast::OpId::Equal,      std::move($1),std::move($3)};}
      |expr NEQ expr      {$$ = ast::Op{{@$,"op"},ast::OpId::NotEq,      std::move($1),std::move($3)};}
      |SUB expr           {$$ = ast::Op{{@$,"op"},ast::OpId::Sub,        std::nullopt, std::move($2)};} %prec UMINUS
      |NOT expr           {$$ = ast::Op{{@$,"op"},ast::OpId::Not,        std::nullopt, std::move($2)};} %prec UMINUS

--- a/test/mmm/test_operators.mmm
+++ b/test/mmm/test_operators.mmm
@@ -1,0 +1,22 @@
+a = 1+2//3
+b = a-2//1
+c = b*2//2
+d = c/2//1
+print(d)
+e = c*3//8
+print(e)
+
+print(2 & 3)//1
+print(2 & 0)//0
+print(2 | 3)//1
+print(2 | 0)//1
+print(2 == 0)//0
+print(2 != 0)//1
+print(2>0)//1
+print(2>=2)//1
+print(2<0)//0
+print(2<=0)//0
+print(2 << 2)//?
+print(128 >> 2) //?
+print(-2)//-2
+println(!2)//0

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -28,6 +28,7 @@ namespace fs = std::filesystem;
   }
 
 REGRESSION(regression, "120")
+REGRESSION(operators,"161011011100832-20\n")
 REGRESSION(typeident, R"(3
 3
 2


### PR DESCRIPTION
This PR fixed missing binary operator `==` and `!=`.
Also regression test for infix operators has been added.