### PR TITLE
Struct Type & Type Alias Implementation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: tomoyanonymous # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
+open_collective: mimium
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/src/basic/ast.hpp
+++ b/src/basic/ast.hpp
@@ -48,13 +48,14 @@ using Expr =
 using ExprPtr = std::shared_ptr<Expr>;
 
 struct Assign;
+struct TypeAssign;
 struct Fdef;
 
 struct Return;
 struct Declaration;
 struct For;
 
-using Statement = std::variant<Assign, Return, Fdef, Time, Fcall, Box<If>, /* Declaration, */
+using Statement = std::variant<Assign,TypeAssign, Return, Fdef, Time, Fcall, Box<If>, /* Declaration, */
                                Box<For>>;
 using Statements = std::deque<std::shared_ptr<Statement>>;
 
@@ -206,6 +207,10 @@ struct Assign : public Base {
   ExprPtr expr;
 };
 
+struct TypeAssign : public Base{
+  std::string name;
+  types::Value val;
+};
 struct Fdef : public Base {
   DeclVar lvar;
   Lambda fun;

--- a/src/basic/ast.hpp
+++ b/src/basic/ast.hpp
@@ -192,7 +192,7 @@ struct Struct : public Base {
 
 struct StructAccess : public Base {
   ExprPtr stru;
-  ExprPtr field;
+  std::string field;
 };
 
 // Time ast, only a function call can be tied with time.

--- a/src/basic/ast.hpp
+++ b/src/basic/ast.hpp
@@ -188,6 +188,7 @@ struct ArrayAccess : public Base {
   ExprPtr index;
 };
 struct Struct : public Base {
+  std::string typesymbol;
   std::deque<ExprPtr> args;
 };
 

--- a/src/basic/ast_to_string.cpp
+++ b/src/basic/ast_to_string.cpp
@@ -51,7 +51,7 @@ void AstStringifier::operator()(const ast::Time& ast) {
   output << format.delim << format.rpar;
 }
 void AstStringifier::operator()(const ast::Struct& ast) {
-  output << format.lpar << "struct" << format.delim;
+  output << format.lpar << "struct" << format.delim << ast.typesymbol;
   toStringVec(ast.args);
   output << format.rpar;
 }

--- a/src/basic/ast_to_string.cpp
+++ b/src/basic/ast_to_string.cpp
@@ -58,8 +58,7 @@ void AstStringifier::operator()(const ast::Struct& ast) {
 void AstStringifier::operator()(const ast::StructAccess& ast) {
   output << format.lpar << "structaccess" << format.delim << format.lpar_a;
   toString(ast.stru);
-  output << format.delim;
-  toString(ast.field);
+  output << format.delim << ast.field;
   output << format.rpar_a << format.rpar;
 }
 void AstStringifier::operator()(const ast::ArrayInit& ast) {

--- a/src/basic/ast_to_string.cpp
+++ b/src/basic/ast_to_string.cpp
@@ -85,6 +85,12 @@ void AstStringifier::operator()(const ast::Assign& ast) {
   toString(ast.expr);
   output << format.rpar;
 }
+void AstStringifier::operator()(const ast::TypeAssign& ast) {
+  output << format.lpar << "typeassign" << format.delim;
+  output << ast.name << format.delim << types::toString(ast.val);;
+  output << format.rpar;
+}
+
 void AstStringifier::operator()(const ast::Fdef& ast) {
   output << format.lpar << "Fdef" << format.delim;
   (*this)(ast.lvar);

--- a/src/basic/ast_to_string.hpp
+++ b/src/basic/ast_to_string.hpp
@@ -49,6 +49,7 @@ struct AstStringifier : public ToStringVisitor {
   void operator()(const ast::DeclVar& ast);
 
   void operator()(const ast::Assign& ast);
+  void operator()(const ast::TypeAssign& ast);
   void operator()(const ast::Return& ast);
   void operator()(const ast::Fdef& ast);
   void operator()(const ast::Time& ast);

--- a/src/basic/helper_functions.hpp
+++ b/src/basic/helper_functions.hpp
@@ -104,21 +104,27 @@ inline bool has(std::vector<std::string> t, char* s) {
   return std::find(t.begin(), t.end(), std::string(s)) != t.end();
 }
 
-template <class ELEMENT, typename LAMBDA>
-using CALLABLE_TRAIT = std::enable_if_t<std::is_invocable_v<LAMBDA, ELEMENT>,std::nullptr_t>;
-
-template <template <class...> class CONTAINER, class ELEMENT, class LAMBDA>
-CONTAINER<ELEMENT> fmap(
-    CONTAINER<ELEMENT> args, LAMBDA lambda) {
-  CONTAINER<ELEMENT> res;
+template <class ELEMENT, class LAMBDA>
+using CALLABLE_TRAIT = std::enable_if<std::is_invocable_v<LAMBDA, ELEMENT>, std::nullptr_t>;
+// helper metafunction which maps container elements with lambda.
+template <template <class...> class CONTAINERIN,template <class...> class CONTAINEROUT=CONTAINERIN,
+          typename ELEMENTIN, typename LAMBDA>
+CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> fmap(CONTAINERIN<ELEMENTIN> args,
+                                                           LAMBDA lambda) {
+  CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> res;
   std::transform(args.cbegin(), args.cend(), std::back_inserter(res), lambda);
-  return res;
+  return std::forward<decltype(res)>(res);
 }
+// // simple version when container type is as same as input container
+// template <template <class...> class CONTAINERIN, typename ELEMENTIN, typename LAMBDA>
+// auto fmap(CONTAINERIN<ELEMENTIN> args, LAMBDA lambda) {
+//   return fmap<CONTAINERIN>(std::move(args), std::move(lambda));
+// }
 
 namespace ast {
 template <typename T, typename L>
 T transformArgs(T& args, L&& lambda) {
-  fmap(args, lambda);
+  return fmap(args, lambda);
 }
 }  // namespace ast
 

--- a/src/basic/helper_functions.hpp
+++ b/src/basic/helper_functions.hpp
@@ -104,22 +104,21 @@ inline bool has(std::vector<std::string> t, char* s) {
   return std::find(t.begin(), t.end(), std::string(s)) != t.end();
 }
 
-template <class ELEMENT, class LAMBDA>
-using CALLABLE_TRAIT = std::enable_if<std::is_invocable_v<LAMBDA, ELEMENT>, std::nullptr_t>;
 // helper metafunction which maps container elements with lambda.
-template <template <class...> class CONTAINERIN,template <class...> class CONTAINEROUT=CONTAINERIN,
-          typename ELEMENTIN, typename LAMBDA>
+// Template-template parameter are input container and output container.
+// Other parameters will be inferred from context.
+// auto hoge = fmap<std::deque,std::vector>(ast.args,[](ExprPtr a){return a.name;});
+// if container between input and output are the same, you can omit template parameter.
+// auto hoge = fmap(ast.args,[](ExprPtr a){return a.name;});
+
+template <template <class...> class CONTAINERIN,
+          template <class...> class CONTAINEROUT = CONTAINERIN, typename ELEMENTIN, typename LAMBDA>
 CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> fmap(CONTAINERIN<ELEMENTIN> args,
                                                            LAMBDA lambda) {
   CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> res;
   std::transform(args.cbegin(), args.cend(), std::back_inserter(res), lambda);
-  return std::forward<decltype(res)>(res);
+  return std::move(res);
 }
-// // simple version when container type is as same as input container
-// template <template <class...> class CONTAINERIN, typename ELEMENTIN, typename LAMBDA>
-// auto fmap(CONTAINERIN<ELEMENTIN> args, LAMBDA lambda) {
-//   return fmap<CONTAINERIN>(std::move(args), std::move(lambda));
-// }
 
 namespace ast {
 template <typename T, typename L>

--- a/src/basic/helper_functions.hpp
+++ b/src/basic/helper_functions.hpp
@@ -26,13 +26,13 @@
 // SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), ENABLE_VIRTUAL_TERMINAL_PROCESSING);
 #endif
 #if defined(__clang__)
-  #if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
-  // code that builds only under AddressSanitizer
-    #define NO_SANITIZE __attribute__((no_sanitize("address", "undefined")))
-  #endif
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+// code that builds only under AddressSanitizer
+#define NO_SANITIZE __attribute__((no_sanitize("address", "undefined")))
+#endif
 #endif
 #ifndef NO_SANITIZE
-  #define NO_SANITIZE
+#define NO_SANITIZE
 #endif
 
 namespace mimium {
@@ -104,12 +104,21 @@ inline bool has(std::vector<std::string> t, char* s) {
   return std::find(t.begin(), t.end(), std::string(s)) != t.end();
 }
 
+template <class ELEMENT, typename LAMBDA>
+using CALLABLE_TRAIT = std::enable_if_t<std::is_invocable_v<LAMBDA, ELEMENT>,std::nullptr_t>;
+
+template <template <class...> class CONTAINER, class ELEMENT, class LAMBDA>
+CONTAINER<ELEMENT> fmap(
+    CONTAINER<ELEMENT> args, LAMBDA lambda) {
+  CONTAINER<ELEMENT> res;
+  std::transform(args.cbegin(), args.cend(), std::back_inserter(res), lambda);
+  return res;
+}
+
 namespace ast {
 template <typename T, typename L>
-T transformArgs(T& args, L lambda) {
-  T res;
-  std::transform(args.begin(), args.end(), std::back_inserter(res), lambda);
-  return res;
+T transformArgs(T& args, L&& lambda) {
+  fmap(args, lambda);
 }
 }  // namespace ast
 

--- a/src/basic/type.cpp
+++ b/src/basic/type.cpp
@@ -22,37 +22,4 @@ void dump(const Value& v, bool verbose) { std::cerr << toString(v, verbose) << "
 
 }  // namespace types
 
-void TypeEnv::replaceTypeVars() {
-  for (auto& [key, val] : env) {
-    if (rv::holds_alternative<types::TypeVar>(val)) {
-      auto& tv = rv::get<types::TypeVar>(val);
-      if (std::holds_alternative<types::None>(tv.contained)) {
-        // throw std::runtime_error("type inference for " + key + " failed");
-        tv.contained = types::Float{};
-      }
-      env[key] = tv.contained;
-    }
-  }
-}
-
-std::string TypeEnv::toString(bool verbose) {
-  std::stringstream ss;
-  types::ToStringVisitor vis;
-  vis.verbose = verbose;
-  for (auto& [key, val] : env) { ss << key << " : " << std::visit(vis, val) << "\n"; }
-  return ss.str();
-}
-void TypeEnv::dump(bool verbose) {
-  std::cerr << "-------------------\n" << toString(verbose) << "-------------------\n";
-}
-void TypeEnv::dumpTvLinks() {
-  std::cerr << "------tvlinks-----\n";
-  int i = 0;
-  for (auto& a : tv_container) {
-    std::cerr << "typevar" << i << " : " << types::toString(a) << "\n";
-    ++i;
-  }
-  std::cerr << "------tvlinks-----" << std::endl;
-}
-
 }  // namespace mimium

--- a/src/basic/type.hpp
+++ b/src/basic/type.hpp
@@ -169,6 +169,18 @@ struct Struct {
   std::vector<Keytype> arg_types;
 };
 
+// return 0-based index and its type of Struct type fields for the key string.
+
+inline std::pair<int, types::Value> getField(types::Struct const& sttype, std::string const& key) {
+  auto iter = std::find_if(sttype.arg_types.cbegin(), sttype.arg_types.cend(),
+                           [&](const auto& a) { return a.field == key; });
+  if (iter == sttype.arg_types.cend()) {
+    throw std::logic_error("failed to find \"" + key + "\" field for struct type");
+  }
+  auto index = std::distance(sttype.arg_types.cbegin(), iter);
+  return std::pair(index, sttype.arg_types.at(index).val);
+};
+
 inline bool operator==(const Struct::Keytype& t1, const Struct::Keytype& t2) {
   return (t1.field == t2.field) && (t1.val == t2.val);
 }
@@ -201,7 +213,7 @@ bool operator!=(T t1, T t2) {
 }
 
 constexpr size_t fixed_delaysize = 44100;
-inline auto getDelayStruct(){
+inline auto getDelayStruct() {
   return types::Alias{"MmmRingBuf", types::Tuple{{types::Float{}, types::Float{},
                                                   types::Array{types::Float{}, fixed_delaysize}}}};
 }

--- a/src/basic/type.hpp
+++ b/src/basic/type.hpp
@@ -288,7 +288,7 @@ class TypeEnv {
  public:
   TypeEnv() : env() {}
   std::unordered_map<std::string, types::Value> env;
-
+  std::unordered_map<std::string, types::Value> alias_map;
   std::deque<types::Value> tv_container;
   std::shared_ptr<types::TypeVar> createNewTypeVar() {
     auto res = std::make_shared<types::TypeVar>(typeid_count++);

--- a/src/basic/type.hpp
+++ b/src/basic/type.hpp
@@ -266,9 +266,12 @@ struct ToStringVisitor {
 std::string toString(const Value& v, bool verbose = false);
 void dump(const Value& v, bool verbose = false);
 
+template<typename T>
+using is_primitive_type = typename std::is_base_of<PrimitiveType, std::decay_t<T>>;
+static_assert(is_primitive_type<types::Float&>::value==true);
 inline bool isPrimitive(const Value& v) {
   return std::visit(
-      [](auto& a) { return std::is_base_of_v<PrimitiveType, std::decay_t<decltype(a)>>; }, v);
+      [](auto& a) { return is_primitive_type<decltype(a)>::value; }, v);
 }
 
 inline bool isClosure(const Value& v) {

--- a/src/basic/variant_visitor_helper.hpp
+++ b/src/basic/variant_visitor_helper.hpp
@@ -6,14 +6,17 @@
 #include <cassert>
 #include <memory>
 #include <variant>
+
 template <class... Ts>
 struct overloaded : Ts... {
   using Ts::operator()...;
 };
 template <class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
+
 namespace mimium {
 // recursive variant
+
 template <typename T>
 struct Box {
   // construct from an existing object
@@ -33,6 +36,8 @@ struct Box {
   std::shared_ptr<T> t;
 };
 
+
+
 template <typename T>
 inline bool operator==(const Box<T>& t1, const Box<T>& t2) {
   return static_cast<const T&>(t1) == static_cast<const T&>(t2);
@@ -41,6 +46,18 @@ template <typename T>
 inline bool operator!=(const Box<T>& t1, const Box<T>& t2) {
   return !(t1 == t2);
 }
+
+template <class... Ts>
+struct overloaded_rec: Ts... {
+  using Ts::operator()...;
+  template <typename T>
+  auto operator()(Box<T> a) {
+    return (*this)(a.getraw());
+  }
+};
+template <class... Ts>
+overloaded_rec(Ts...) -> overloaded_rec<Ts...>;
+
 
 template <typename RETTYPE>
 class VisitorBase {

--- a/src/compiler/closure_convert.cpp
+++ b/src/compiler/closure_convert.cpp
@@ -140,9 +140,7 @@ void ClosureConverter::CCVisitor::operator()(minst::Function& i) {
     }
     ++it;
   }
-  std::vector<mir::valueptr> fvsetvec;
-  std::transform(ccvis.fvset.begin(), ccvis.fvset.end(), std::back_inserter(fvsetvec),
-                 [](auto& i) { return i; });
+  auto fvsetvec = fmap<std::set,std::vector>(ccvis.fvset,[](auto i){return i;});
   i.freevariables = fvsetvec;  // copy;
   // do not use auto here, move happens...
   types::Alias fvtype{cc.makeCaptureName(), types::Tuple{fvtype_inside}};

--- a/src/compiler/codegen/codegen_visitor.cpp
+++ b/src/compiler/codegen/codegen_visitor.cpp
@@ -511,7 +511,8 @@ llvm::Value* CodeGenVisitor::operator()(minst::Array& i) {
   return gvalue;
 }
 llvm::Value* CodeGenVisitor::operator()(minst::ArrayAccess& i) {
-  auto* target = getLlvmVal(i.target);
+  auto* targetp = getLlvmVal(i.target);
+  llvm::Value* target = G.builder->CreateLoad(targetp);
   auto* index = getLlvmVal(i.index);
   auto* arraccessfun = G.module->getFunction("access_array_lin_interp");
   auto* dptrty = arraccessfun->getArg(0)->getType();

--- a/src/compiler/codegen/codegen_visitor.cpp
+++ b/src/compiler/codegen/codegen_visitor.cpp
@@ -503,9 +503,8 @@ llvm::Value* CodeGenVisitor::operator()(minst::MakeClosure& i) {
 llvm::Value* CodeGenVisitor::operator()(minst::Array& i) {
   auto* atype = G.getArrayType(i.type);
   auto* gvalue = llvm::cast<llvm::GlobalVariable>(G.module->getOrInsertGlobal(i.name, atype));
-  std::vector<llvm::Constant*> values = {};
-  std::transform(i.args.cbegin(), i.args.cend(), std::back_inserter(values),
-                 [&](mir::valueptr v) { return llvm::cast<llvm::Constant>(getLlvmVal(v)); });
+  auto values =
+      fmap(i.args, [&](mir::valueptr v) { return llvm::cast<llvm::Constant>(getLlvmVal(v)); });
   auto* constantarray = llvm::ConstantArray::get(atype, values);
   gvalue->setInitializer(constantarray);
   return gvalue;

--- a/src/compiler/codegen/codegen_visitor.cpp
+++ b/src/compiler/codegen/codegen_visitor.cpp
@@ -511,8 +511,8 @@ llvm::Value* CodeGenVisitor::operator()(minst::Array& i) {
   return gvalue;
 }
 llvm::Value* CodeGenVisitor::operator()(minst::ArrayAccess& i) {
-  auto* targetp = getLlvmVal(i.target);
-  llvm::Value* target = G.builder->CreateLoad(targetp);
+  auto* target = getLlvmVal(i.target);
+  // llvm::Value* target = G.builder->CreateLoad(targetp);
   auto* index = getLlvmVal(i.index);
   auto* arraccessfun = G.module->getFunction("access_array_lin_interp");
   auto* dptrty = arraccessfun->getArg(0)->getType();

--- a/src/compiler/mimium.l
+++ b/src/compiler/mimium.l
@@ -79,6 +79,7 @@ NEWLINE {BREAK}* | ";"
 "void" return token::TYPEVOID;
 "string" return token::TYPESTRING;
 "Fn" return token::TYPEFN;
+"type" return token::TYPEIDENT;
 
 ":" return token::TYPE_DELIM;
 

--- a/src/compiler/mimium.yy
+++ b/src/compiler/mimium.yy
@@ -311,6 +311,7 @@ types:
       | fntype     { $$=std::move($1);}
       | tupletype  { $$=std::move($1);}
       | structtype { $$=std::move($1);}
+      | SYMBOL     { $$=types::Alias{std::move($1),types::None{}};}
 
 // Type Declaration
 

--- a/src/compiler/mimium.yy
+++ b/src/compiler/mimium.yy
@@ -299,11 +299,11 @@ typeargs:  typeargs ',' types { $1.emplace_back(std::move($3));
                                 $$ = std::move($1); }
       |    types { $$ = std::vector<types::Value>{$1};}
       
-structtype: '{' strutypeargs '}' { $$ = types::Struct{std::move($2)}; }
+structtype: LBRACE strutypeargs RBRACE { $$ = types::Struct{std::move($2)}; }
 
 strutypeargs : strutypeargs ',' strutypearg { $1.emplace_back(std::move($3));$$ = std::move($1); }
             | strutypearg {$$ = std::vector<types::Struct::Keytype>{$1}; }
-strutypearg : SYMBOL ':' types { $$ = types::Struct::Keytype{std::move($1),std::move($3)}; }
+strutypearg : SYMBOL TYPE_DELIM types { $$ = types::Struct::Keytype{std::move($1),std::move($3)}; }
 
 types: 
         primtypes  { $$=std::move($1);}

--- a/src/compiler/mimium.yy
+++ b/src/compiler/mimium.yy
@@ -178,7 +178,7 @@ namespace mimium{
 
 
 %type <ast::ArrayAccess> array_access "array access"
-
+%type <ast::Struct> structconstruct "struct"
 %type <ast::StructAccess> structaccess "struct access"
 
 %type <ast::Assign> assign "assign"
@@ -377,6 +377,7 @@ array_access: expr '[' expr ']' {
       // @$ = {@1.first_line,@1.first_col,@4.last_line,@4.last_col};
       $$ = ast::ArrayAccess{{@$,"arrayaccess"},std::move($1),std::move($3)};}
 
+structconstruct: SYMBOL LBRACE tupleargs RBRACE {$$ =ast::Struct{{@$,"struct"},std::move($1),std::move($3)};}
 structaccess: expr '.' SYMBOL {$$ = ast::StructAccess{{@$,"structaccess"},std::move($1),std::move($3)};}
 
 tupleargs: expr ',' expr {$$ = std::deque<ast::ExprPtr>{std::move($1),std::move($3)};}
@@ -419,14 +420,15 @@ ifstmt: IF cond expr   {$$ = ast::If{{@$,"if"},std::move($2),std::move($3),std::
    |IF cond expr ELSE expr {$$ = ast::If{{@$,"if"},std::move($2),std::move($3),std::move($5)};} %prec ELSE_EXPR
 
 
-expr_non_fcall:op      {$$ = ast::makeExpr($1);}
-      |    array     {$$ = ast::makeExpr($1);}
-      | array_access {$$ = ast::makeExpr($1);}
-      | structaccess {$$ = ast::makeExpr($1);}
-      |     tuple    {$$ = ast::makeExpr($1);}%prec TUPLE
-      |    lambda    {$$ = ast::makeExpr($1);}
-      |    single    {$$ = std::move($1);}
-      |'(' expr ')' {$$ = std::move($2);}
+expr_non_fcall:op       {$$ = ast::makeExpr($1);}
+      |    array        {$$ = ast::makeExpr($1);}
+      | array_access    {$$ = ast::makeExpr($1);}
+      | structconstruct {$$ = ast::makeExpr($1);}
+      | structaccess    {$$ = ast::makeExpr($1);}
+      |     tuple       {$$ = ast::makeExpr($1);}%prec TUPLE
+      |    lambda       {$$ = ast::makeExpr($1);}
+      |    single       {$$ = std::move($1);}
+      |'(' expr ')'     {$$ = std::move($2);}
       // | term {$$ = std::move($1);}
 
 expr: expr_non_fcall {$$ = std::move($1);}

--- a/src/compiler/mimium.yy
+++ b/src/compiler/mimium.yy
@@ -99,6 +99,7 @@ namespace mimium{
    TYPEVOID "typeid:void"
    TYPEFN "typeid:fn"
    TYPESTRING "typeid:string"
+   TYPEIDENT "type identifier"
 
    INCLUDE "include"
 
@@ -126,6 +127,7 @@ namespace mimium{
 %type <std::vector<types::Value>> typeargs "typeargs"
 %type <std::vector<types::Struct::Keytype>> strutypeargs "struct args"
 %type <types::Struct::Keytype> strutypearg "struct arg"
+%type <ast::TypeAssign> typedecl "typedecl"
 
 %type <ast::Number> num "number"
 
@@ -310,6 +312,10 @@ types:
       | tupletype  { $$=std::move($1);}
       | structtype { $$=std::move($1);}
 
+// Type Declaration
+
+typedecl: TYPEIDENT SYMBOL ASSIGN types {$$ = ast::TypeAssign{{@$,"typeassign"},std::move($2),std::move($4)}; }
+
 // Expression Section
 // temporarily debug symbol for aggregate ast is disabled
 
@@ -459,14 +465,13 @@ statements: opt_nl statement{  $$ = std::deque<std::shared_ptr<ast::Statement>>{
                                           $$= std::move($1);  }
             
 statement: assign       {$$=ast::makeStatement(std::move($1));} 
+          |typedecl     {$$=ast::makeStatement(std::move($1));} 
           |fdef         {$$=ast::makeStatement(std::move($1));}
           |forloop      {$$=ast::makeStatement(std::move($1));}
-      //     |declaration  {$$=ast::makeStatement(std::move($1));}
-          |RETURN expr  {auto ret = ast::Return{{@$,"ret"},std::move($2)};
-                         $$=ast::makeStatement(std::move(ret));}
-          |fcalltime     {$$=ast::makeStatement(std::move($1));}
-          |fcall         {$$=ast::makeStatement(std::move($1));}
-          |ifstmt         {$$=ast::makeStatement(std::move($1));}
+          |RETURN expr  {$$=ast::makeStatement(ast::Return{{@$,"ret"},std::move($2)});}
+          |fcalltime    {$$=ast::makeStatement(std::move($1));}
+          |fcall        {$$=ast::makeStatement(std::move($1));}
+          |ifstmt       {$$=ast::makeStatement(std::move($1));}
 
 
 block: LBRACE   statements newlines expr_non_fcall opt_nl RBRACE {$$ = ast::Block{{@$,"block"},std::move($2),std::optional(std::move($4))};}

--- a/src/compiler/mirgenerator.cpp
+++ b/src/compiler/mirgenerator.cpp
@@ -366,6 +366,10 @@ void StatementKnormVisitor::operator()(ast::Assign& ast) {
   auto visitor = AssignKnormVisitor(exprvisitor.mirgen, exprvisitor, ast.expr);
   std::visit(visitor, ast.lvar);
 }
+void StatementKnormVisitor::operator()(ast::TypeAssign& /*ast*/) {
+  //do nothing
+}
+
 void StatementKnormVisitor::operator()(ast::Return& ast) {
   auto val = exprvisitor.genInst(ast.value);
   auto type = mir::getType(*val);

--- a/src/compiler/mirgenerator.cpp
+++ b/src/compiler/mirgenerator.cpp
@@ -213,9 +213,15 @@ mir::valueptr ExprKnormVisitor::operator()(ast::Struct& /*ast*/) {
   // TODO(tomoya)
   return nullptr;
 }
-mir::valueptr ExprKnormVisitor::operator()(ast::StructAccess& /*ast*/) {
-  // TODO(tomoya)
-  return nullptr;
+mir::valueptr ExprKnormVisitor::operator()(ast::StructAccess& ast) {
+  auto lvname = mirgen.makeNewName();
+  auto target = genInst(ast.stru);
+  auto type = mir::getType(*target);
+  assert(rv::holds_alternative<types::Struct>(type));
+  auto& strtype = rv::get<types::Struct>(type);
+  auto [index, fieldtype] = types::getField(strtype, ast.field);
+  return emplace(minst::Field{
+      {lvname, fieldtype}, target, std::make_shared<mir::Value>(mir::Constants(index))});
 }
 mir::valueptr ExprKnormVisitor::operator()(ast::ArrayInit& ast) {
   auto lvname = mirgen.makeNewName();

--- a/src/compiler/mirgenerator.hpp
+++ b/src/compiler/mirgenerator.hpp
@@ -152,14 +152,6 @@ class MirGenerator {
   std::pair<optvalptr, mir::blockptr> generateBlock(ast::Block& block, std::string label,
                                                     optvalptr const& fnctx);
 
-  // expect return value
-  // auto emplaceExpr(mir::Instructions&& inst) { return require(emplace(std::move(inst))); }
-  template <typename FROM, typename TO, class LAMBDA>
-  auto transformArgs(FROM&& from, TO&& to, LAMBDA&& op) -> decltype(to) {
-    std::transform(from.begin(), from.end(), std::back_inserter(to), op);
-    return std::forward<decltype(to)>(to);
-  }
-
   optvalptr genIfInst(ast::If& ast);
 
   static bool isPassByValue(types::Value const& type);
@@ -181,8 +173,8 @@ class MirGenerator {
   // // unpack optional value ptr, and throw error if it does not exist.
   static mir::valueptr require(optvalptr const& v);
 
-  std::function<std::shared_ptr<mir::Argument>(ast::DeclVar&)> make_arguments =
-      [&](ast::DeclVar& lvar) {
+  std::function<std::shared_ptr<mir::Argument>(ast::DeclVar)>  make_arguments =
+      [&](ast::DeclVar lvar) {
         auto& name = lvar.value.value;
         auto type = typeenv.find(name);
         if (!isPassByValue(type)) { type = types::makePointer(type); }

--- a/src/compiler/mirgenerator.hpp
+++ b/src/compiler/mirgenerator.hpp
@@ -49,6 +49,7 @@ class MirGenerator {
     const std::optional<mir::valueptr>& fnctx;
 
    private:
+    mir::valueptr genExprArray(std::deque<ast::ExprPtr>const& args);
     std::pair<optvalptr, mir::blockptr> genIfBlock(ast::ExprPtr& block, std::string const& label);
 
     mir::blockptr block;

--- a/src/compiler/mirgenerator.hpp
+++ b/src/compiler/mirgenerator.hpp
@@ -16,7 +16,7 @@ namespace mir {
 
 inline types::Value lowerType(types::Value const& t) {
   return std::visit(
-      overloaded{
+      overloaded_rec{
           [](auto i) { 
           assert(types::is_primitive_type<decltype(i)>);
           return  types::Value{i}; },
@@ -28,10 +28,10 @@ inline types::Value lowerType(types::Value const& t) {
           //   assert(false);
           //   return types::Value{i};
           // },
-          // [](types::Pointer i) {
-          //   assert(false);
-          //   return types::Value{i};
-          // },
+          [](types::Pointer i) {
+            // assert(false);
+            return types::Value{i};
+          },
           // [](types::Closure i) {
           //   assert(false);
           //   return types::Value{i};
@@ -49,15 +49,15 @@ inline types::Value lowerType(types::Value const& t) {
             return types::Value{res};
           },
           [](types::Array i) {
-            return types::Value{types::Ref{types::Array{lowerType(i.elem_type), i.size}}};
+            return types::Value{types::Pointer{types::Array{lowerType(i.elem_type), i.size}}};
           },
           [](types::Struct i) {
-            return types::Value{types::Ref{types::Struct{fmap(i.arg_types, [](auto const& a) {
+            return types::Value{types::Pointer{types::Struct{fmap(i.arg_types, [](auto const& a) {
               return types::Struct::Keytype{a.field, lowerType(a.val)};
             })}}};
           },
           [](types::Tuple i) {
-            return types::Value{types::Ref{
+            return types::Value{types::Pointer{
                 types::Tuple{fmap(i.arg_types, [](auto const& i) { return lowerType(i); })}}};
           },
           [](types::Alias i) {

--- a/src/compiler/mirgenerator.hpp
+++ b/src/compiler/mirgenerator.hpp
@@ -75,6 +75,7 @@ class MirGenerator {
           mirgen(evisitor.mirgen){}
 
     void operator()(ast::Assign& ast);
+    void operator()(ast::TypeAssign& ast);
     void operator()(ast::Fdef& ast);
     void operator()(ast::Return& ast);
     void operator()(ast::Time& ast);

--- a/src/compiler/symbolrenamer.cpp
+++ b/src/compiler/symbolrenamer.cpp
@@ -105,7 +105,7 @@ ast::ExprPtr ExprRenameVisitor::operator()(ast::Struct& ast) {
   return ast::makeExpr(ast::Struct{{{ast.debuginfo}}, std::move(newargs)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::StructAccess& ast) {
-  return ast::makeExpr(ast::StructAccess{{{ast.debuginfo}}, rename(ast.stru), rename(ast.field)});
+  return ast::makeExpr(ast::StructAccess{{{ast.debuginfo}}, rename(ast.stru), ast.field});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::ArrayInit& ast) {
   auto newargs =

--- a/src/compiler/symbolrenamer.cpp
+++ b/src/compiler/symbolrenamer.cpp
@@ -161,6 +161,9 @@ StatementPtr StatementRenameVisitor::operator()(ast::Assign& ast) {
   auto newrvar = renamer.renameExpr(ast.expr);
   return ast::makeStatement(ast::Assign{{{ast.debuginfo}}, std::move(newlvar), std::move(newrvar)});
 }
+StatementPtr StatementRenameVisitor::operator()(ast::TypeAssign& ast) {
+    return ast::makeStatement(ast);
+}
 StatementPtr StatementRenameVisitor::operator()(ast::Return& ast) {
   return ast::makeStatement(ast::Return{{{ast.debuginfo}}, renamer.renameExpr(ast.value)});
 }

--- a/src/compiler/symbolrenamer.cpp
+++ b/src/compiler/symbolrenamer.cpp
@@ -102,7 +102,7 @@ ast::ExprPtr ExprRenameVisitor::operator()(ast::Fcall& ast) {
 ast::ExprPtr ExprRenameVisitor::operator()(ast::Struct& ast) {
   auto newargs =
       ast::transformArgs(ast.args, [&](ast::ExprPtr e) { return renamer.renameExpr(e); });
-  return ast::makeExpr(ast::Struct{{{ast.debuginfo}}, std::move(newargs)});
+  return ast::makeExpr(ast::Struct{{{ast.debuginfo}}, ast.typesymbol, std::move(newargs)});
 }
 ast::ExprPtr ExprRenameVisitor::operator()(ast::StructAccess& ast) {
   return ast::makeExpr(ast::StructAccess{{{ast.debuginfo}}, rename(ast.stru), ast.field});
@@ -162,7 +162,7 @@ StatementPtr StatementRenameVisitor::operator()(ast::Assign& ast) {
   return ast::makeStatement(ast::Assign{{{ast.debuginfo}}, std::move(newlvar), std::move(newrvar)});
 }
 StatementPtr StatementRenameVisitor::operator()(ast::TypeAssign& ast) {
-    return ast::makeStatement(ast);
+  return ast::makeStatement(ast);
 }
 StatementPtr StatementRenameVisitor::operator()(ast::Return& ast) {
   return ast::makeStatement(ast::Return{{{ast.debuginfo}}, renamer.renameExpr(ast.value)});

--- a/src/compiler/symbolrenamer.hpp
+++ b/src/compiler/symbolrenamer.hpp
@@ -59,6 +59,7 @@ class SymbolRenamer {
     explicit StatementRenameVisitor(SymbolRenamer& parent) : renamer(parent){};
     SymbolRenamer& renamer;
     StatementPtr operator()(ast::Assign& ast);
+    StatementPtr operator()(ast::TypeAssign& ast);
     StatementPtr operator()(ast::Fdef& ast);
 
     StatementPtr operator()(ast::Return& ast);

--- a/src/compiler/type_infer_visitor.cpp
+++ b/src/compiler/type_infer_visitor.cpp
@@ -70,8 +70,9 @@ types::Value ExprTypeVisitor::operator()(ast::StructAccess& ast) {
         "operator.");
   }
   auto& stru = rv::get<types::Struct>(stru_type);
+  auto[index,fieldtype] = types::getField(stru, ast.field);
   // todo(tomoya): need to restrict field ast to rvar, not an term
-  return stru.arg_types.at(0).val;
+  return fieldtype;
 }
 types::Value ExprTypeVisitor::operator()(ast::ArrayInit& ast) {
   std::vector<types::Value> argtypes;

--- a/src/compiler/type_infer_visitor.cpp
+++ b/src/compiler/type_infer_visitor.cpp
@@ -221,9 +221,8 @@ types::Value TypeUnifyVisitor::unify(types::rRef p1, types::rRef p2) {
   auto target = inferer.unify(p1.getraw().val, p2.getraw().val);
   return types::Ref{target};
 }
-types::Value TypeUnifyVisitor::unify(types::rAlias a1, types::rAlias a2) {
-  return inferer.unify(a1.getraw().target, a2.getraw().target);
-  ;
+types::Value TypeUnifyVisitor::unify(types::Alias a1, types::Alias a2) {
+  return inferer.unify(a1.target, a2.target);
 }
 types::Value TypeUnifyVisitor::unify(types::rFunction f1, types::rFunction f2) {
   auto argtype = unifyArgs(f1.getraw().arg_types, f2.getraw().arg_types);

--- a/src/compiler/type_infer_visitor.cpp
+++ b/src/compiler/type_infer_visitor.cpp
@@ -159,6 +159,10 @@ types::Value StatementTypeVisitor::operator()(ast::Assign& ast) {
   std::visit(assignvisitor, ast.lvar);
   return types::Void{};
 }
+types::Value StatementTypeVisitor::operator()(ast::TypeAssign& ast) {
+  inferer.typeenv.alias_map.emplace(ast.name,ast.val);
+  return types::Void{};
+}
 types::Value StatementTypeVisitor::operator()(ast::Return& ast) {
   return inferer.inferExpr(ast.value);
 }

--- a/src/compiler/type_infer_visitor.cpp
+++ b/src/compiler/type_infer_visitor.cpp
@@ -228,18 +228,18 @@ types::Value TypeUnifyVisitor::unify(types::rRef p1, types::rRef p2) {
   auto target = inferer.unify(p1.getraw().val, p2.getraw().val);
   return types::Ref{target};
 }
-types::Value TypeUnifyVisitor::unify(types::Alias& a1, types::Alias& a2) {
-  auto aliasupdater = [&](types::Alias& a) {
-    auto& amap = inferer.typeenv.alias_map;
+void TypeUnifyVisitor::updateAlias(types::Alias& a)const{
+      auto& amap = inferer.typeenv.alias_map;
     if (amap.find(a.name) != amap.cend()) {
-      a.target = amap.at(a1.name);
+      a.target = amap.at(a.name);
     } else {
       throw std::runtime_error("Unknown Type Name:" + a.name);
     }
-  };
-  aliasupdater(a1);
-  aliasupdater(a2);
-  return inferer.unify(a1.target, a2.target);
+}
+types::Value TypeUnifyVisitor::unify(types::rAlias& a1, types::rAlias& a2) {
+  updateAlias(a1);
+  updateAlias(a2);
+  return inferer.unify(a1.getraw().target, a2.getraw().target);
 }
 types::Value TypeUnifyVisitor::unify(types::rFunction f1, types::rFunction f2) {
   auto argtype = unifyArgs(f1.getraw().arg_types, f2.getraw().arg_types);

--- a/src/compiler/type_infer_visitor.cpp
+++ b/src/compiler/type_infer_visitor.cpp
@@ -221,7 +221,17 @@ types::Value TypeUnifyVisitor::unify(types::rRef p1, types::rRef p2) {
   auto target = inferer.unify(p1.getraw().val, p2.getraw().val);
   return types::Ref{target};
 }
-types::Value TypeUnifyVisitor::unify(types::Alias a1, types::Alias a2) {
+types::Value TypeUnifyVisitor::unify(types::Alias& a1, types::Alias& a2) {
+  auto aliasupdater = [&](types::Alias& a){
+    auto& amap =inferer.typeenv.alias_map;
+    if (amap.find(a.name)!=amap.cend()){
+      a.target = amap.at(a1.name);
+    }else{
+      throw std::runtime_error("Unknown Type Name:" + a.name);
+    }
+  };
+  aliasupdater(a1);
+  aliasupdater(a2);
   return inferer.unify(a1.target, a2.target);
 }
 types::Value TypeUnifyVisitor::unify(types::rFunction f1, types::rFunction f2) {

--- a/src/compiler/type_infer_visitor.hpp
+++ b/src/compiler/type_infer_visitor.hpp
@@ -128,7 +128,7 @@ struct TypeInferer {
     types::Value unify(types::rTypeVar t1, types::rTypeVar t2);
     types::Value unify(types::rPointer p1, types::rPointer p2);
     types::Value unify(types::rRef p1, types::rRef p2);
-    types::Value unify(types::Alias a1, types::Alias a2);
+    types::Value unify(types::Alias& a1, types::Alias& a2);
     template <typename T>
     types::Value unify(T a1, T /*a2*/) {
       return a1;

--- a/src/compiler/type_infer_visitor.hpp
+++ b/src/compiler/type_infer_visitor.hpp
@@ -48,6 +48,7 @@ struct OccurChecker {
 };
 
 struct TypeInferer {
+  using TypeEnvT = TypeEnvProto<ast::ExprPtr>;
   struct ExprTypeVisitor : public VisitorBase<types::Value> {
     explicit ExprTypeVisitor(TypeInferer& parent) : inferer(parent) {}
     types::Value operator()(ast::Op& ast);
@@ -244,7 +245,9 @@ struct TypeInferer {
         statementvisitor(*this),
         unifyvisitor(*this),
         substitutevisitor(*this) {
-    for (const auto& [key, val] : LLVMBuiltin::ftable) { typeenv.emplace(key, val.mmmtype); }
+    for (const auto& [key, val] : LLVMBuiltin::ftable) {
+      typeenv.emplace(key, val.mmmtype);
+    }
     typeenv.emplace("mimium_getnow", types::Function{types::Float{}, {}});
   }
   // entry point.

--- a/src/compiler/type_infer_visitor.hpp
+++ b/src/compiler/type_infer_visitor.hpp
@@ -128,21 +128,22 @@ struct TypeInferer {
     types::Value unify(types::rTypeVar t1, types::rTypeVar t2);
     types::Value unify(types::rPointer p1, types::rPointer p2);
     types::Value unify(types::rRef p1, types::rRef p2);
-    types::Value unify(types::rAlias a1, types::rAlias a2);
+    types::Value unify(types::Alias a1, types::Alias a2);
     template <typename T>
     types::Value unify(T a1, T /*a2*/) {
       return a1;
     }
+    template <typename T>
+    using TypeVarAliasTrait =
+        typename std::enable_if<std::is_same_v<std::decay_t<T>, types::TypeVar>>::type;
 
-    template <typename T, typename std::enable_if<
-                              std::is_same_v<std::decay_t<T>, types::TypeVar>>::type = nullptr>
-    types::Value unify(types::rAlias a1, T a2) {
-      return std::visit(*this, a1.getraw().target, types::Value(a2));
+    template <typename T, TypeVarAliasTrait<T>>
+    types::Value unify(types::Alias a1, T a2) {
+      return std::visit(*this, a1.target, types::Value(a2));
     }
-    template <typename T, typename std::enable_if<
-                              std::is_same_v<std::decay_t<T>, types::TypeVar>>::type = nullptr>
+    template <typename T, TypeVarAliasTrait<T>>
     types::Value unify(T a1, types::rAlias a2) {
-      return std::visit(*this, types::Value(a1), a2.getraw().target);
+      return unify(a2, a1);
     }
     types::Value unify(types::rFunction f1, types::rFunction f2);
     types::Value unify(types::rArray a1, types::rArray a2);

--- a/src/compiler/type_infer_visitor.hpp
+++ b/src/compiler/type_infer_visitor.hpp
@@ -76,6 +76,7 @@ struct TypeInferer {
     explicit StatementTypeVisitor(TypeInferer& parent) : inferer(parent) {}
     types::Value operator()(ast::Fdef& ast);
     types::Value operator()(ast::Assign& ast);
+    types::Value operator()(ast::TypeAssign& ast);
     types::Value operator()(ast::Return& ast);
     types::Value operator()(ast::Time& ast);
 

--- a/test/2.parser_test.cpp
+++ b/test/2.parser_test.cpp
@@ -28,6 +28,7 @@ PARSER_TEST(tuplelvar)
 PARSER_TEST(tuple)
 PARSER_TEST(tupletype)
 PARSER_TEST(typedecl)
+PARSER_TEST(structaccess)
 
 TEST(parser, ast_complete) {//NOLINT
   Driver driver{};

--- a/test/2.parser_test.cpp
+++ b/test/2.parser_test.cpp
@@ -27,6 +27,7 @@ PARSER_TEST(array)
 PARSER_TEST(tuplelvar)
 PARSER_TEST(tuple)
 PARSER_TEST(tupletype)
+PARSER_TEST(typedecl)
 
 TEST(parser, ast_complete) {//NOLINT
   Driver driver{};

--- a/test/2.parser_test.cpp
+++ b/test/2.parser_test.cpp
@@ -28,6 +28,7 @@ PARSER_TEST(tuplelvar)
 PARSER_TEST(tuple)
 PARSER_TEST(tupletype)
 PARSER_TEST(typedecl)
+PARSER_TEST(struct)
 PARSER_TEST(structaccess)
 
 TEST(parser, ast_complete) {//NOLINT

--- a/test/mmm/parser/struct.mmm
+++ b/test/mmm/parser/struct.mmm
@@ -1,0 +1,1 @@
+hoge = customtype{ 100,"mystring", test }

--- a/test/mmm/parser/structaccess.mmm
+++ b/test/mmm/parser/structaccess.mmm
@@ -1,0 +1,1 @@
+hoge = mystruct.field1

--- a/test/mmm/parser/typedecl.mmm
+++ b/test/mmm/parser/typedecl.mmm
@@ -1,0 +1,3 @@
+type stereo = (float,float)
+
+type mystru = { hoge:float,fuga:string }

--- a/test/mmm/test_structtype.mmm
+++ b/test/mmm/test_structtype.mmm
@@ -1,0 +1,9 @@
+type a = {key1:float,key2:string}
+fn test(){
+    hoge = a{999,"something"}
+    fuga = hoge.key1 //should be 100
+    println(fuga)
+    //TBD
+    // hoge.key1 = 999
+}
+test()

--- a/test/mmm/test_typealias.mmm
+++ b/test/mmm/test_typealias.mmm
@@ -1,0 +1,12 @@
+type stereo = (float,float)
+
+type composite = {signal:stereo , id:float}
+fn test2(){
+    ogya = composite{(100,200), 100}
+    ho,fu = ogya.signal
+    he = ogya.id
+    println(ho)
+    println(fu)
+    println(he)
+}
+test2()

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -77,3 +77,4 @@ REGRESSION(arrayreturn, "100\n200\n300\n400\n500\n")
 REGRESSION(arraylvar, "600\n700\n800\n")
 
 REGRESSION(structtype, "999\n")
+REGRESSION(typealias, "100\n200\n100\n")

--- a/test/regression/regression_test.cpp
+++ b/test/regression/regression_test.cpp
@@ -76,3 +76,5 @@ REGRESSION(array_capture, "100\n200\n300\n400\n500\n")
 REGRESSION(array_tofun, "100\n200\n300\n400\n500\n")
 REGRESSION(arrayreturn, "100\n200\n300\n400\n500\n")
 REGRESSION(arraylvar, "600\n700\n800\n")
+
+REGRESSION(structtype, "999\n")

--- a/test/test_structtype.mmm
+++ b/test/test_structtype.mmm
@@ -1,0 +1,5 @@
+type a = {key1:float,key2:string}
+
+hoge = a{100,"something"}
+
+fuga = a.key1 //should be 100

--- a/test/test_structtype.mmm
+++ b/test/test_structtype.mmm
@@ -1,5 +1,0 @@
-type a = {key1:float,key2:string}
-
-hoge = a{100,"something"}
-
-fuga = a.key1 //should be 100


### PR DESCRIPTION
implement struct type(record type) and type alias. Example is in `test_typealias.mmm` in `test/mmm`.
```rust
type stereo = (float,float)

type composite = {signal:stereo , id:float}
fn test2(){
    ogya = composite{(100,200), 100}
    ho,fu = ogya.signal
    he = ogya.id
    println(ho)
    println(fu)
    println(he)
}
test2()
```