### PR TITLE
Use std::filesystem::weakly_canonical() to avoid filesyste_error

### DIFF
--- a/src/basic/filereader.cpp
+++ b/src/basic/filereader.cpp
@@ -32,7 +32,7 @@ std::pair<fs::path, FileType> getFilePath(std::string_view val) {
 
 FileReader::FileReader(fs::path cwd) : cwd(std::move(cwd)) {}
 Source FileReader::loadFile(std::string const& path) {
-  auto [srcpath, type] = getFilePath(fs::canonical(fs::relative(path, cwd)).string());
+  auto [srcpath, type] = getFilePath(fs::weakly_canonical(fs::relative(path, cwd)).string());
   Source res{fs::absolute(srcpath), type, ""};
   // memo: fs::exists(path,ec) for .mmm file returns file type of "unknown", not "regular" or
   // "none". to prevent error, need to check specifically not to be "not found"


### PR DESCRIPTION
This PR fixes a bug about path normalization.

## Bug behavior

This bug occurs when the users specify absolute path but it actually **does not exist**. When `mimium` command is passed such a path, the command fails like this:

```shell-session
$ $ mimium /path/does/not/exist/foo.mmm
filesystem error: cannot make canonical path: No such file or directory [../../../../path/does/not/exist/foo.mmm]
```

Additionally, if a path specified exists, `mimium` command normalizes the path and then continues its process.

I found [this behavior](https://gist.github.com/t-sin/c5ff1adc538bca0eaae09fbb6f29c3cd) in development of [mimium mapckage manager](https://github.com/mimium-org/mmmpm).

## The cause of this bug

`mimium` does path normalization at first of its process but it has not done correctly.

The path normalization has done at this point:

https://github.com/mimium-org/mimium/blob/263f357adc910e7b9ac1c503294c66c7ea5ad56a/src/frontend/genericapp.cpp#L64

According to [this page](https://en.cppreference.com/w/cpp/filesystem/canonical), the function `std::filesystem::canonical()` throws `filesystem_error` when the path does not exist. That page also says that the function does fully existence check for all path elements. 

## How to fix

That page also says `std::filesystem::weakly_canonical()` does the path normalization partially. It means that the specified path  so the path entirely may not exist.

If using `weakly_canonical()` instead of `canonical()`, the `mimium` command successfully normalizes at the point of the source code, checks input path existence then handles by the situation by itself, like this:

```shell-session
$ cmake --build ./build/ -j && ./build/src/mimium /path/does/not/exist/foo.mmm
File not found: /path/does/not/exist/foo.mmm
```
So, in this PR's case, using `weakly_canonical()` is better.



