### PR TITLE
Add struct assignment semantics.

### DIFF
--- a/src/basic/ast.hpp
+++ b/src/basic/ast.hpp
@@ -19,7 +19,8 @@ struct Symbol;
 struct DeclVar;
 struct ArrayLvar;
 struct TupleLvar;
-using Lvar = std::variant<DeclVar, ArrayLvar, TupleLvar>;
+struct StructLvar;
+using Lvar = std::variant<DeclVar, ArrayLvar, TupleLvar,StructLvar>;
 struct TypeSpec;
 
 // struct Rvar;
@@ -143,6 +144,11 @@ struct ArrayLvar : public Base {
 };
 struct TupleLvar : public Base {
   std::deque<DeclVar> args;
+};
+
+struct StructLvar: public Base{
+  ExprPtr stru;
+  Symbol field;
 };
 
 struct Self : public Base {

--- a/src/basic/ast_to_string.cpp
+++ b/src/basic/ast_to_string.cpp
@@ -135,6 +135,12 @@ void AstStringifier::operator()(const ast::TupleLvar& ast) {
   toStringVec(ast.args);
   output << format.rpar_a << format.delim << format.rpar;
 }
+void AstStringifier::operator()(const ast::StructLvar& ast) {
+  output << format.lpar << "arraylvar" << format.delim;
+  toString(ast.stru);
+  output << format.delim << ast.field << format.rpar;
+}
+
 void AstStringifier::operator()(const ast::DeclVar& ast) {
   output << format.lpar << "lvar" << format.delim << ast.value;
   if (ast.type.has_value()) {

--- a/src/basic/ast_to_string.hpp
+++ b/src/basic/ast_to_string.hpp
@@ -46,6 +46,8 @@ struct AstStringifier : public ToStringVisitor {
 
   void operator()(const ast::ArrayLvar& ast);
   void operator()(const ast::TupleLvar& ast);
+  void operator()(const ast::StructLvar& ast);
+
   void operator()(const ast::DeclVar& ast);
 
   void operator()(const ast::Assign& ast);

--- a/src/basic/helper_functions.hpp
+++ b/src/basic/helper_functions.hpp
@@ -113,18 +113,19 @@ inline bool has(std::vector<std::string> t, char* s) {
 
 template <template <class...> class CONTAINERIN,
           template <class...> class CONTAINEROUT = CONTAINERIN, typename ELEMENTIN, typename LAMBDA>
-CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> fmap(CONTAINERIN<ELEMENTIN> args,
-                                                           LAMBDA lambda) {
+CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> fmap(CONTAINERIN<ELEMENTIN> const& args,
+                                                           LAMBDA&& lambda) {
   static_assert(std::is_invocable_v<LAMBDA, ELEMENTIN>, "the function for fmap is not invocable");
   CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> res;
-  std::transform(args.cbegin(), args.cend(), std::back_inserter(res), lambda);
+  std::transform(args.cbegin(), args.cend(), std::back_inserter(res),
+                 std::forward<decltype(lambda)>(lambda));
   return std::move(res);
 }
 
 namespace ast {
 template <typename T, typename L>
 T transformArgs(T& args, L&& lambda) {
-  return fmap(args, lambda);
+  return fmap(args, std::forward<decltype(lambda)>(lambda));
 }
 }  // namespace ast
 

--- a/src/basic/helper_functions.hpp
+++ b/src/basic/helper_functions.hpp
@@ -115,6 +115,7 @@ template <template <class...> class CONTAINERIN,
           template <class...> class CONTAINEROUT = CONTAINERIN, typename ELEMENTIN, typename LAMBDA>
 CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> fmap(CONTAINERIN<ELEMENTIN> args,
                                                            LAMBDA lambda) {
+  static_assert(std::is_invocable_v<LAMBDA, ELEMENTIN>, "the function for fmap is not invocable");
   CONTAINEROUT<std::invoke_result_t<LAMBDA, ELEMENTIN>> res;
   std::transform(args.cbegin(), args.cend(), std::back_inserter(res), lambda);
   return std::move(res);

--- a/src/basic/type.hpp
+++ b/src/basic/type.hpp
@@ -115,10 +115,8 @@ inline bool operator==(const Pointer& t1, const Pointer& t2) { return t1.val == 
 // Helper function to make pointer to pointer type
 // Because nested aggregate initialization like Pointer{Pointer{Float}} interpreted as copy
 // construction.
-inline auto makePointer(types::Value&& t) {
-  types::Pointer res;
-  res.val = std::forward<types::Value>(t);
-  return std::forward<types::Value>(res);
+inline types::Value makePointer(types::Value&& t) {
+  return types::Pointer{std::move(t)};
 }
 inline auto makePointer(types::Value const& t) {
   types::Pointer res;

--- a/src/basic/type.hpp
+++ b/src/basic/type.hpp
@@ -275,6 +275,18 @@ bool isA(const Value& v) {
 }
 
 template <typename T>
+std::optional<T> getIf(Value const& v) {
+  if(isA<types::rAlias>(v)){
+    return getIf<T>(rv::get<types::Alias>(v).target);
+  }
+  if(std::holds_alternative<T>(v)){
+    return std::optional(std::get<T>(v));
+  }
+  return std::nullopt;
+}
+
+
+template <typename T>
 constexpr bool is_primitive_type = std::is_base_of_v<PrimitiveType, std::decay_t<T>>;
 
 inline bool isPrimitive(const Value& v) {

--- a/src/basic/variant_visitor_helper.hpp
+++ b/src/basic/variant_visitor_helper.hpp
@@ -52,7 +52,7 @@ constexpr bool isBoxed(Box<T> /*v*/) {
   return true;
 }
 template <typename T>
-using boxenabler = std::enable_if_t<isBoxed(std::declval<std::decay_t<T>>())>;
+using boxenabler = std::enable_if_t<isBoxed(T())>;
 
 template <class... Ts>
 struct overloaded_rec : Ts... {

--- a/src/compiler/codegen/typeconverter.hpp
+++ b/src/compiler/codegen/typeconverter.hpp
@@ -36,7 +36,8 @@ struct TypeConverter {
 
  private:
   [[nodiscard]] std::string consumeAlias();
-  [[nodiscard]] llvm::Type* tryGetNamedType(std::string& name) const;
+  llvm::Type* convertTypeArray(std::vector<llvm::Type*>&& tarray);
+  [[nodiscard]] std::optional<llvm::Type*> tryGetNamedType(std::string& name) const;
 };
 
 }  // namespace mimium

--- a/src/compiler/mimium.yy
+++ b/src/compiler/mimium.yy
@@ -133,6 +133,8 @@ namespace mimium{
 
 %type <ast::DeclVar> declvar "lvar variable declaration"
 %type <ast::ArrayLvar> arrayLvar "array access lvar"
+%type <ast::StructLvar> structLvar "struct access lvar"
+
 %type <std::deque<ast::DeclVar>> tuplelvar_args "tuplelvar_args"
 %type <ast::TupleLvar> tupleLvar "tuple unpack"
 
@@ -271,9 +273,14 @@ tupleLvar: tuplelvar_args {
       auto arg = std::deque<ast::DeclVar>{std::move($1)};
       $$ = ast::TupleLvar{{@$,"tuplelvar"},std::move(arg)};}
 
-lvar: declvar{ $$ = std::move($1);}
-     | arrayLvar{ $$ = std::move($1);}
-     | tupleLvar{ $$ = std::move($1);}
+structLvar: expr '.' symbol {
+      $$ = ast::StructLvar{{@$,"structlvar"},std::move($1),std::move($3)};}      
+
+
+lvar: declvar    { $$ = std::move($1);}
+     | arrayLvar { $$ = std::move($1);}
+     | tupleLvar { $$ = std::move($1);}
+     | structLvar{ $$ = std::move($1);}
 
 symbol: SYMBOL {
             @$ = @1;
@@ -378,6 +385,7 @@ array_access: expr '[' expr ']' {
       $$ = ast::ArrayAccess{{@$,"arrayaccess"},std::move($1),std::move($3)};}
 
 structconstruct: SYMBOL LBRACE tupleargs RBRACE {$$ =ast::Struct{{@$,"struct"},std::move($1),std::move($3)};}
+            |SYMBOL LBRACE expr RBRACE  {$$ =ast::Struct{{@$,"struct"},std::move($1),std::deque<ast::ExprPtr>{std::move($3)}};}
 structaccess: expr '.' SYMBOL {$$ = ast::StructAccess{{@$,"structaccess"},std::move($1),std::move($3)};}
 
 tupleargs: expr ',' expr {$$ = std::deque<ast::ExprPtr>{std::move($1),std::move($3)};}

--- a/src/compiler/mirgenerator.hpp
+++ b/src/compiler/mirgenerator.hpp
@@ -119,6 +119,7 @@ class MirGenerator {
     void operator()(ast::DeclVar& ast);
     void operator()(ast::ArrayLvar& ast);
     void operator()(ast::TupleLvar& ast);
+    void operator()(ast::StructLvar& ast);
 
    private:
     MirGenerator& mirgen;

--- a/src/compiler/mirgenerator.hpp
+++ b/src/compiler/mirgenerator.hpp
@@ -17,9 +17,10 @@ namespace mir {
 inline types::Value lowerType(types::Value const& t) {
   return std::visit(
       overloaded_rec{
-          [](auto i) { 
-          assert(types::is_primitive_type<decltype(i)>);
-          return  types::Value{i}; },
+          [](auto const& i) {
+            assert(types::is_primitive_type<decltype(i)>);
+            return types::Value{i};
+          },
           // [](types::TypeVar i) {
           //   assert(false);
           //   return types::Value{i};
@@ -28,7 +29,7 @@ inline types::Value lowerType(types::Value const& t) {
           //   assert(false);
           //   return types::Value{i};
           // },
-          [](types::Pointer i) {
+          [](types::Pointer const& i) {
             // assert(false);
             return types::Value{i};
           },
@@ -37,7 +38,7 @@ inline types::Value lowerType(types::Value const& t) {
           //   return types::Value{i};
           // },
 
-          [](types::Function i) {
+          [](types::Function const& i) {
             types::Function res;
             if (types::isAggregate(i.ret_type)) {
               res.ret_type = types::Void{};
@@ -48,19 +49,19 @@ inline types::Value lowerType(types::Value const& t) {
             for (const auto& a : i.arg_types) { res.arg_types.emplace_back(a); }
             return types::Value{res};
           },
-          [](types::Array i) {
+          [](types::Array const& i) {
             return types::Value{types::Pointer{types::Array{lowerType(i.elem_type), i.size}}};
           },
-          [](types::Struct i) {
+          [](types::Struct const& i) {
             return types::Value{types::Pointer{types::Struct{fmap(i.arg_types, [](auto const& a) {
               return types::Struct::Keytype{a.field, lowerType(a.val)};
             })}}};
           },
-          [](types::Tuple i) {
+          [](types::Tuple const& i) {
             return types::Value{types::Pointer{
                 types::Tuple{fmap(i.arg_types, [](auto const& i) { return lowerType(i); })}}};
           },
-          [](types::Alias i) {
+          [](types::Alias const& i) {
             return types::Value{types::Alias{i.name, lowerType(i.target)}};
           },
       },
@@ -106,7 +107,7 @@ class MirGenerator {
     const std::optional<mir::valueptr>& fnctx;
 
    private:
-    mir::valueptr genExprArray(std::deque<ast::ExprPtr>const& args);
+    mir::valueptr genExprArray(std::deque<ast::ExprPtr> const& args);
     std::pair<optvalptr, mir::blockptr> genIfBlock(ast::ExprPtr& block, std::string const& label);
 
     mir::blockptr block;
@@ -174,7 +175,7 @@ class MirGenerator {
   // // unpack optional value ptr, and throw error if it does not exist.
   static mir::valueptr require(optvalptr const& v);
 
-  std::function<std::shared_ptr<mir::Argument>(ast::DeclVar)>  make_arguments =
+  std::function<std::shared_ptr<mir::Argument>(ast::DeclVar)> make_arguments =
       [&](ast::DeclVar lvar) {
         auto& name = lvar.value.value;
         auto type = typeenv.find(name);

--- a/src/compiler/symbolrenamer.cpp
+++ b/src/compiler/symbolrenamer.cpp
@@ -148,6 +148,10 @@ ast::Lvar LvarRenameVisitor::operator()(ast::TupleLvar& ast) {
       ast.args, [&](ast::DeclVar a) { return renamer.lvar_renamevisitor.renameDeclVar(a); });
   return ast::TupleLvar{{{ast.debuginfo}}, newargs};
 }
+ast::Lvar LvarRenameVisitor::operator()(ast::StructLvar& ast) {
+  return ast::StructLvar{{{ast.debuginfo}}, renamer.renameExpr(ast.stru), ast.field};
+}
+
 using StatementRenameVisitor = SymbolRenamer::StatementRenameVisitor;
 
 StatementPtr StatementRenameVisitor::operator()(ast::Fdef& ast) {

--- a/src/compiler/symbolrenamer.hpp
+++ b/src/compiler/symbolrenamer.hpp
@@ -51,6 +51,7 @@ class SymbolRenamer {
     ast::Lvar operator()(ast::DeclVar& ast);
     ast::Lvar operator()(ast::ArrayLvar& ast);
     ast::Lvar operator()(ast::TupleLvar& ast);
+    ast::Lvar operator()(ast::StructLvar& ast);
     ast::DeclVar renameDeclVar(ast::DeclVar& ast);
     ast::DeclVar renameLambdaArgVar(ast::DeclVar& ast);
     ast::Lvar rename(ast::Lvar& ast) { return std::visit(*this, ast); }


### PR DESCRIPTION
Thi pr adds semantics for destructive assignment to struct type variables by dot operator like `hoge.val = fuga`.

Note that the implementation is still in work in progress.